### PR TITLE
Enhance mediator service builder with new handler methods

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -18,56 +18,6 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
 
 jobs:
-  format-check:
-    name: Code Formatting Check
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v5
-      with:
-        fetch-depth: 0
-        
-    - name: Setup .NET SDK 9.0.x
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: '9.0.x'
-        
-    - name: Restore dotnet tools
-      run: dotnet tool restore
-      
-    - name: Check code formatting with CSharpier
-      id: format-check
-      run: dotnet csharpier check .
-      continue-on-error: true
-      
-    - name: Comment on PR if formatting issues found
-      if: steps.format-check.outcome == 'failure'
-      uses: actions/github-script@v7
-      with:
-        script: |
-          const comment = `## ❌ Code Formatting Check Failed
-          
-          The code formatting check failed. Please run the following command to fix formatting issues:
-          
-          \`\`\`bash
-          dotnet csharpier format .
-          \`\`\`
-          
-          Then commit and push the changes.`;
-          
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: comment
-          });
-          
-    - name: Fail job if formatting issues found
-      if: steps.format-check.outcome == 'failure'
-      run: exit 1
-
   documentation-check:
     name: XML Documentation Check
     runs-on: ubuntu-latest
@@ -158,8 +108,8 @@ jobs:
   build-and-test:
     name: Build and Test
     runs-on: ubuntu-latest
-    needs: [format-check, documentation-check]
-    if: always() && (needs.format-check.result == 'success' || needs.format-check.result == 'skipped') && (needs.documentation-check.result == 'success' || needs.documentation-check.result == 'skipped')
+    needs: [documentation-check]
+    if: always() && (needs.documentation-check.result == 'success' || needs.documentation-check.result == 'skipped')
     
     steps:
     - name: Checkout code
@@ -199,7 +149,7 @@ jobs:
   package:
     name: Package and Publish
     runs-on: ubuntu-latest
-    needs: [format-check, build-and-test, changes]
+    needs: [build-and-test, changes]
     if: (github.ref == 'refs/heads/main' && needs.changes.outputs.src == 'true') || startsWith(github.ref, 'refs/tags/v')
     
     steps:

--- a/README.md
+++ b/README.md
@@ -386,7 +386,8 @@ builder.Services.AddNetMediate()
     .IgnoreUnhandledMessages(ignore: true, log: true, logLevel: LogLevel.Warning)
     .FilterCommand<CreateUserCommand, CreateUserCommandHandler>(cmd => cmd.Email.EndsWith("@company.com"))
     .InstantiateHandlerByMessageFilter<DynamicMessage>(msg => 
-        msg.Type == "urgent" ? typeof(UrgentMessageHandler) : typeof(StandardMessageHandler));
+        msg.Type == "urgent" ? typeof(UrgentMessageHandler) : typeof(StandardMessageHandler))
+    .RegisterNotificationHandler<DummyNotificationMessage, DummyNotificationHandler>();
 ```
 
 ## Framework Support

--- a/net-mediate.slnx
+++ b/net-mediate.slnx
@@ -11,6 +11,9 @@
     <Project Path="src/NetMediate/NetMediate.csproj" Id="232b3170-ace0-4adb-a81d-541c5b872bac" />
   </Folder>
   <Folder Name="/tests/">
-    <Project Path="tests/NetMediate.Tests/NetMediate.Tests.csproj" Id="7c9982c0-0795-4743-988d-be05f7cd797b" />
+    <Project
+      Path="tests/NetMediate.Tests/NetMediate.Tests.csproj"
+      Id="7c9982c0-0795-4743-988d-be05f7cd797b"
+    />
   </Folder>
 </Solution>

--- a/net-mediate.slnx
+++ b/net-mediate.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/.sln/">
+    <File Path=".github/workflows/ci-cd.yml" />
     <File Path=".gitignore" />
     <File Path="LICENSE" />
     <File Path="pack.props" />
@@ -10,9 +11,6 @@
     <Project Path="src/NetMediate/NetMediate.csproj" Id="232b3170-ace0-4adb-a81d-541c5b872bac" />
   </Folder>
   <Folder Name="/tests/">
-    <Project
-      Path="tests/NetMediate.Tests/NetMediate.Tests.csproj"
-      Id="7c9982c0-0795-4743-988d-be05f7cd797b"
-    />
+    <Project Path="tests/NetMediate.Tests/NetMediate.Tests.csproj" Id="7c9982c0-0795-4743-988d-be05f7cd797b" />
   </Folder>
 </Solution>

--- a/src/NetMediate/IMediatorServiceBuilder.cs
+++ b/src/NetMediate/IMediatorServiceBuilder.cs
@@ -84,6 +84,13 @@ public interface IMediatorServiceBuilder
     /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
     IMediatorServiceBuilder RegisterNotificationHandler<TMessage, THandler>()
         where THandler : class, INotificationHandler<TMessage> =>
+    /// Registers a notification handler for a specific message type.
+    /// </summary>
+    /// <typeparam name="TMessage">The type of the message to handle.</typeparam>
+    /// <typeparam name="THandler">The type of the notification handler.</typeparam>
+    /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
+    IMediatorServiceBuilder RegisterNotificationHandler<TMessage, THandler>()
+        where THandler : class, INotificationHandler<TMessage> =>
         Register(typeof(TMessage), typeof(THandler));
 
     /// <summary>

--- a/src/NetMediate/IMediatorServiceBuilder.cs
+++ b/src/NetMediate/IMediatorServiceBuilder.cs
@@ -123,7 +123,7 @@ public interface IMediatorServiceBuilder
     /// <summary>
     /// Registers a stream handler for a specific message type.
     /// </summary>
-    /// <typeparam name="TMessage">The type of the message to validate.</typeparam>
+    /// <typeparam name="TMessage">The type of the message to handle.</typeparam>
     /// <typeparam name="THandler">The type of the validation handler.</typeparam>
     /// </summary>
     /// <typeparam name="TMessage">The type of the message to handle.</typeparam>

--- a/src/NetMediate/IMediatorServiceBuilder.cs
+++ b/src/NetMediate/IMediatorServiceBuilder.cs
@@ -75,4 +75,62 @@ public interface IMediatorServiceBuilder
     IMediatorServiceBuilder InstantiateHandlerByMessageFilter<TMessage>(
         Func<TMessage, Type?> filter
     );
+
+    /// <summary>
+    /// Registers a notification handler for a specific message type.
+    /// </summary>
+    /// <typeparam name="TMessage">The type of the message to validate.</typeparam>
+    /// <typeparam name="THandler">The type of the validation handler.</typeparam>
+    /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
+    IMediatorServiceBuilder RegisterNotificationHandler<TMessage, THandler>()
+        where THandler : class, INotificationHandler<TMessage> =>
+        Register(typeof(TMessage), typeof(THandler));
+
+    /// <summary>
+    /// Registers a command handler for a specific message type.
+    /// </summary>
+    /// <typeparam name="TMessage">The type of the message to validate.</typeparam>
+    /// <typeparam name="THandler">The type of the validation handler.</typeparam>
+    /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
+    IMediatorServiceBuilder RegisterCommandHandler<TMessage, THandler>()
+        where THandler : class, ICommandHandler<TMessage> =>
+        Register(typeof(TMessage), typeof(THandler));
+
+    /// <summary>
+    /// Registers a request handler for a specific message type.
+    /// </summary>
+    /// <typeparam name="TMessage">The type of the message to validate.</typeparam>
+    /// <typeparam name="THandler">The type of the validation handler.</typeparam>
+    /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
+    IMediatorServiceBuilder RegisterRequestHandler<TMessage, THandler>()
+        where THandler : class, IRequestHandler<TMessage, object> =>
+        Register(typeof(TMessage), typeof(THandler));
+
+    /// <summary>
+    /// Registers a stream handler for a specific message type.
+    /// </summary>
+    /// <typeparam name="TMessage">The type of the message to validate.</typeparam>
+    /// <typeparam name="THandler">The type of the validation handler.</typeparam>
+    /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
+    IMediatorServiceBuilder RegisterStreamHandler<TMessage, THandler>()
+        where THandler : class, IStreamHandler<TMessage, object> =>
+        Register(typeof(TMessage), typeof(THandler));
+
+    /// <summary>
+    /// Registers a validation handler for a specific message type.
+    /// </summary>
+    /// <typeparam name="TMessage">The type of the message to validate.</typeparam>
+    /// <typeparam name="THandler">The type of the validation handler.</typeparam>
+    /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
+    IMediatorServiceBuilder RegisterValidationHandler<TMessage, THandler>()
+        where THandler : class, IValidationHandler<TMessage> =>
+        Register(typeof(TMessage), typeof(THandler));
+
+    /// <summary>
+    /// Registers a message type with its corresponding handler type in the mediator service builder.
+    /// </summary>
+    /// <param name="messageType">A type representing the message to be handled.</param>
+    /// <param name="handlerType">A type representing the handler for the message.</param>
+    /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
+    IMediatorServiceBuilder Register(Type messageType, Type handlerType);
 }

--- a/src/NetMediate/IMediatorServiceBuilder.cs
+++ b/src/NetMediate/IMediatorServiceBuilder.cs
@@ -4,62 +4,73 @@ using Microsoft.Extensions.Logging;
 namespace NetMediate;
 
 /// <summary>
-/// Provides a builder interface for configuring mediator services and message handler filters.
+/// Fluent builder for configuring mediator services: registering handlers, attaching per-handler predicates (filters),
+/// customizing handler instantiation, and setting behavior for unhandled messages.
 /// </summary>
 public interface IMediatorServiceBuilder
 {
     /// <summary>
-    /// Gets the service collection used for dependency injection.
+    /// Gets the DI service collection being configured.
     /// </summary>
     IServiceCollection Services { get; }
 
     /// <summary>
-    /// Adds a filter for a specific command handler type.
+    /// Registers a predicate that determines whether a specific command handler should execute
+    /// for a given <typeparamref name="TMessage"/> instance.
     /// </summary>
-    /// <typeparam name="TMessage">The type of the command message.</typeparam>
-    /// <typeparam name="THandler">The type of the command handler.</typeparam>
-    /// <param name="filter">A function to determine if the handler should process the message.</param>
-    /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
+    /// <typeparam name="TMessage">The command (message) type.</typeparam>
+    /// <typeparam name="THandler">The handler type implementing <see cref="ICommandHandler{TMessage}"/>.</typeparam>
+    /// <param name="filter">Predicate returning true to allow execution; false to skip.</param>
+    /// <returns>This builder for chaining.</returns>
     IMediatorServiceBuilder FilterCommand<TMessage, THandler>(Func<TMessage, bool> filter)
         where THandler : class, ICommandHandler<TMessage>;
 
     /// <summary>
-    /// Adds a filter for a specific notification handler type.
+    /// Registers a predicate that determines whether a specific notification handler should execute
+    /// for a given <typeparamref name="TMessage"/> instance.
     /// </summary>
-    /// <typeparam name="TMessage">The type of the notification message.</typeparam>
-    /// <typeparam name="THandler">The type of the notification handler.</typeparam>
-    /// <param name="filter">A function to determine if the handler should process the message.</param>
-    /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
+    /// <typeparam name="TMessage">The notification message type.</typeparam>
+    /// <typeparam name="THandler">The handler type implementing <see cref="INotificationHandler{TMessage}"/>.</typeparam>
+    /// <param name="filter">Predicate returning true to allow execution; false to skip.</param>
+    /// <returns>This builder for chaining.</returns>
     IMediatorServiceBuilder FilterNotification<TMessage, THandler>(Func<TMessage, bool> filter)
         where THandler : class, INotificationHandler<TMessage>;
 
     /// <summary>
-    /// Adds a filter for a specific request handler type.
+    /// Registers a predicate that determines whether a specific request handler should execute
+    /// for a given <typeparamref name="TMessage"/> instance.
     /// </summary>
-    /// <typeparam name="TMessage">The type of the request message.</typeparam>
-    /// <typeparam name="THandler">The type of the request handler.</typeparam>
-    /// <param name="filter">A function to determine if the handler should process the message.</param>
-    /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
+    /// <remarks>
+    /// The handler constraint uses <c>object</c> as the response type; consider a generic overload if stronger typing is desired.
+    /// </remarks>
+    /// <typeparam name="TMessage">The request message type.</typeparam>
+    /// <typeparam name="THandler">The handler type implementing <see cref="IRequestHandler{TRequest,TResponse}"/> for <typeparamref name="TMessage"/>.</typeparam>
+    /// <param name="filter">Predicate returning true to allow execution; false to skip.</param>
+    /// <returns>This builder for chaining.</returns>
     IMediatorServiceBuilder FilterRequest<TMessage, THandler>(Func<TMessage, bool> filter)
         where THandler : class, IRequestHandler<TMessage, object>;
 
     /// <summary>
-    /// Adds a filter for a specific stream handler type.
+    /// Registers a predicate that determines whether a specific stream handler should execute
+    /// for a given <typeparamref name="TMessage"/> instance.
     /// </summary>
-    /// <typeparam name="TMessage">The type of the stream message.</typeparam>
-    /// <typeparam name="THandler">The type of the stream handler.</typeparam>
-    /// <param name="filter">A function to determine if the handler should process the message.</param>
-    /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
+    /// <remarks>
+    /// The handler constraint uses <c>object</c> as the streamed item type; consider a generic overload if stronger typing is desired.
+    /// </remarks>
+    /// <typeparam name="TMessage">The streamed request message type.</typeparam>
+    /// <typeparam name="THandler">The handler type implementing <see cref="IStreamHandler{TRequest,TItem}"/> for <typeparamref name="TMessage"/>.</typeparam>
+    /// <param name="filter">Predicate returning true to allow execution; false to skip.</param>
+    /// <returns>This builder for chaining.</returns>
     IMediatorServiceBuilder FilterStream<TMessage, THandler>(Func<TMessage, bool> filter)
         where THandler : class, IStreamHandler<TMessage, object>;
 
     /// <summary>
-    /// Configures the behavior for unhandled messages.
+    /// Configures how unhandled messages are treated.
     /// </summary>
-    /// <param name="ignore">If true, unhandled messages will be ignored.</param>
-    /// <param name="log">If true, unhandled messages will be logged.</param>
-    /// <param name="logLevel">The log level to use for unhandled messages.</param>
-    /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
+    /// <param name="ignore">If true, absence of a handler does not throw.</param>
+    /// <param name="log">If true, unhandled messages are logged.</param>
+    /// <param name="logLevel">Log level used when <paramref name="log"/> is true.</param>
+    /// <returns>This builder for chaining.</returns>
     IMediatorServiceBuilder IgnoreUnhandledMessages(
         bool ignore = true,
         bool log = true,
@@ -67,99 +78,72 @@ public interface IMediatorServiceBuilder
     );
 
     /// <summary>
-    /// Registers a filter to instantiate a handler type based on the message instance.
+    /// Registers a factory predicate that can dynamically select (instantiate) a handler type based on the message instance.
     /// </summary>
-    /// <typeparam name="TMessage">The type of the message.</typeparam>
-    /// <param name="filter">A function that returns the handler type for the given message, or null if none.</param>
-    /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
+    /// <typeparam name="TMessage">The message type.</typeparam>
+    /// <param name="filter">
+    /// Function returning the handler <see cref="Type"/> that should process the supplied message, or null to indicate no dynamic handler.
+    /// </param>
+    /// <returns>This builder for chaining.</returns>
     IMediatorServiceBuilder InstantiateHandlerByMessageFilter<TMessage>(
         Func<TMessage, Type?> filter
     );
 
     /// <summary>
-    /// Registers a notification handler for a specific message type.
+    /// Registers a notification handler for <typeparamref name="TMessage"/>.
     /// </summary>
-    /// <typeparam name="TMessage">The type of the message to validate.</typeparam>
-    /// <typeparam name="THandler">The type of the validation handler.</typeparam>
-    /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
-    IMediatorServiceBuilder RegisterNotificationHandler<TMessage, THandler>()
-        where THandler : class, INotificationHandler<TMessage> =>
-    /// Registers a notification handler for a specific message type.
-    /// </summary>
-    /// <typeparam name="TMessage">The type of the message to handle.</typeparam>
-    /// <typeparam name="THandler">The type of the notification handler.</typeparam>
-    /// <typeparam name="TMessage">The type of the message to validate.</typeparam>
-    /// <typeparam name="THandler">The type of the notification handler.</typeparam>
-    /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
+    /// <typeparam name="TMessage">The notification message type.</typeparam>
+    /// <typeparam name="THandler">The handler implementing <see cref="INotificationHandler{TMessage}"/>.</typeparam>
+    /// <returns>This builder for chaining.</returns>
     IMediatorServiceBuilder RegisterNotificationHandler<TMessage, THandler>()
         where THandler : class, INotificationHandler<TMessage> =>
         Register(typeof(TMessage), typeof(THandler));
 
     /// <summary>
-    /// Registers a command handler for a specific message type.
+    /// Registers a command handler for <typeparamref name="TMessage"/>.
     /// </summary>
-    /// <typeparam name="TMessage">The type of the message to validate.</typeparam>
-    /// <typeparam name="TMessage">The type of the message to handle.</typeparam>
-    /// <typeparam name="THandler">The type of the command handler.</typeparam>
-    /// <typeparam name="TMessage">The type of the message to validate.</typeparam>
-    /// <typeparam name="THandler">The type of the command handler.</typeparam>
-    /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
+    /// <typeparam name="TMessage">The command message type.</typeparam>
+    /// <typeparam name="THandler">The handler implementing <see cref="ICommandHandler{TMessage}"/>.</typeparam>
+    /// <returns>This builder for chaining.</returns>
     IMediatorServiceBuilder RegisterCommandHandler<TMessage, THandler>()
         where THandler : class, ICommandHandler<TMessage> =>
         Register(typeof(TMessage), typeof(THandler));
 
     /// <summary>
-    /// Registers a request handler for a specific message type.
+    /// Registers a request handler for <typeparamref name="TMessage"/>.
     /// </summary>
-    /// <typeparam name="TMessage">The type of the message to validate.</typeparam>
-    /// <typeparam name="THandler">The type of the validation handler.</typeparam>
-    /// <typeparam name="TMessage">The type of the message to validate.</typeparam>
-    /// <typeparam name="THandler">The type of the request handler.</typeparam>
-    /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
+    /// <typeparam name="TMessage">The request message type.</typeparam>
+    /// <typeparam name="THandler">The handler implementing <see cref="IRequestHandler{TRequest,TResponse}"/> for <typeparamref name="TMessage"/>.</typeparam>
+    /// <returns>This builder for chaining.</returns>
     IMediatorServiceBuilder RegisterRequestHandler<TMessage, THandler>()
         where THandler : class, IRequestHandler<TMessage, object> =>
         Register(typeof(TMessage), typeof(THandler));
 
     /// <summary>
-    /// Registers a stream handler for a specific message type.
+    /// Registers a stream handler for <typeparamref name="TMessage"/>.
     /// </summary>
-    /// <typeparam name="TMessage">The type of the message to handle.</typeparam>
-    /// <typeparam name="THandler">The type of the validation handler.</typeparam>
-    /// </summary>
-    /// <typeparam name="TMessage">The type of the message to handle.</typeparam>
-    /// <typeparam name="THandler">The type of the validation handler.</typeparam>
-    /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
-    IMediatorServiceBuilder RegisterRequestHandler<TMessage, THandler>()
-        where THandler : class, IRequestHandler<TMessage, object> =>
-        Register(typeof(TMessage), typeof(THandler));
-
-    /// <summary>
-    /// Registers a stream handler for a specific message type.
-    /// </summary>
-    /// <typeparam name="TMessage">The type of the message to handle.</typeparam>
-    /// <typeparam name="THandler">The type of the validation handler.</typeparam>
-    /// <typeparam name="TMessage">The type of the message to validate.</typeparam>
-    /// <typeparam name="THandler">The type of the stream handler.</typeparam>
-    /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
+    /// <typeparam name="TMessage">The stream request message type.</typeparam>
+    /// <typeparam name="THandler">The handler implementing <see cref="IStreamHandler{TRequest,TItem}"/> for <typeparamref name="TMessage"/>.</typeparam>
+    /// <returns>This builder for chaining.</returns>
     IMediatorServiceBuilder RegisterStreamHandler<TMessage, THandler>()
         where THandler : class, IStreamHandler<TMessage, object> =>
         Register(typeof(TMessage), typeof(THandler));
 
     /// <summary>
-    /// Registers a validation handler for a specific message type.
+    /// Registers a validation handler for <typeparamref name="TMessage"/>.
     /// </summary>
-    /// <typeparam name="TMessage">The type of the message to validate.</typeparam>
-    /// <typeparam name="THandler">The type of the validation handler.</typeparam>
-    /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
+    /// <typeparam name="TMessage">The message type validated.</typeparam>
+    /// <typeparam name="THandler">The handler implementing <see cref="IValidationHandler{TMessage}"/>.</typeparam>
+    /// <returns>This builder for chaining.</returns>
     IMediatorServiceBuilder RegisterValidationHandler<TMessage, THandler>()
         where THandler : class, IValidationHandler<TMessage> =>
         Register(typeof(TMessage), typeof(THandler));
 
     /// <summary>
-    /// Registers a message type with its corresponding handler type in the mediator service builder.
+    /// Core registration API mapping a message type to a handler type.
     /// </summary>
-    /// <param name="messageType">A type representing the message to be handled.</param>
-    /// <param name="handlerType">A type representing the handler for the message.</param>
-    /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
+    /// <param name="messageType">The message type.</param>
+    /// <param name="handlerType">The handler type.</param>
+    /// <returns>This builder for chaining.</returns>
     IMediatorServiceBuilder Register(Type messageType, Type handlerType);
 }

--- a/src/NetMediate/IMediatorServiceBuilder.cs
+++ b/src/NetMediate/IMediatorServiceBuilder.cs
@@ -88,6 +88,8 @@ public interface IMediatorServiceBuilder
     /// </summary>
     /// <typeparam name="TMessage">The type of the message to handle.</typeparam>
     /// <typeparam name="THandler">The type of the notification handler.</typeparam>
+    /// <typeparam name="TMessage">The type of the message to validate.</typeparam>
+    /// <typeparam name="THandler">The type of the notification handler.</typeparam>
     /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
     IMediatorServiceBuilder RegisterNotificationHandler<TMessage, THandler>()
         where THandler : class, INotificationHandler<TMessage> =>

--- a/src/NetMediate/IMediatorServiceBuilder.cs
+++ b/src/NetMediate/IMediatorServiceBuilder.cs
@@ -99,7 +99,8 @@ public interface IMediatorServiceBuilder
     /// Registers a command handler for a specific message type.
     /// </summary>
     /// <typeparam name="TMessage">The type of the message to validate.</typeparam>
-    /// <typeparam name="THandler">The type of the validation handler.</typeparam>
+    /// <typeparam name="TMessage">The type of the message to handle.</typeparam>
+    /// <typeparam name="THandler">The type of the command handler.</typeparam>
     /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
     IMediatorServiceBuilder RegisterCommandHandler<TMessage, THandler>()
         where THandler : class, ICommandHandler<TMessage> =>

--- a/src/NetMediate/IMediatorServiceBuilder.cs
+++ b/src/NetMediate/IMediatorServiceBuilder.cs
@@ -101,6 +101,8 @@ public interface IMediatorServiceBuilder
     /// <typeparam name="TMessage">The type of the message to validate.</typeparam>
     /// <typeparam name="TMessage">The type of the message to handle.</typeparam>
     /// <typeparam name="THandler">The type of the command handler.</typeparam>
+    /// <typeparam name="TMessage">The type of the message to validate.</typeparam>
+    /// <typeparam name="THandler">The type of the command handler.</typeparam>
     /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
     IMediatorServiceBuilder RegisterCommandHandler<TMessage, THandler>()
         where THandler : class, ICommandHandler<TMessage> =>

--- a/src/NetMediate/IMediatorServiceBuilder.cs
+++ b/src/NetMediate/IMediatorServiceBuilder.cs
@@ -138,6 +138,8 @@ public interface IMediatorServiceBuilder
     /// </summary>
     /// <typeparam name="TMessage">The type of the message to handle.</typeparam>
     /// <typeparam name="THandler">The type of the validation handler.</typeparam>
+    /// <typeparam name="TMessage">The type of the message to validate.</typeparam>
+    /// <typeparam name="THandler">The type of the stream handler.</typeparam>
     /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
     IMediatorServiceBuilder RegisterStreamHandler<TMessage, THandler>()
         where THandler : class, IStreamHandler<TMessage, object> =>

--- a/src/NetMediate/IMediatorServiceBuilder.cs
+++ b/src/NetMediate/IMediatorServiceBuilder.cs
@@ -113,6 +113,8 @@ public interface IMediatorServiceBuilder
     /// </summary>
     /// <typeparam name="TMessage">The type of the message to validate.</typeparam>
     /// <typeparam name="THandler">The type of the validation handler.</typeparam>
+    /// <typeparam name="TMessage">The type of the message to validate.</typeparam>
+    /// <typeparam name="THandler">The type of the request handler.</typeparam>
     /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
     IMediatorServiceBuilder RegisterRequestHandler<TMessage, THandler>()
         where THandler : class, IRequestHandler<TMessage, object> =>

--- a/src/NetMediate/IMediatorServiceBuilder.cs
+++ b/src/NetMediate/IMediatorServiceBuilder.cs
@@ -123,6 +123,19 @@ public interface IMediatorServiceBuilder
     /// </summary>
     /// <typeparam name="TMessage">The type of the message to validate.</typeparam>
     /// <typeparam name="THandler">The type of the validation handler.</typeparam>
+    /// </summary>
+    /// <typeparam name="TMessage">The type of the message to handle.</typeparam>
+    /// <typeparam name="THandler">The type of the validation handler.</typeparam>
+    /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
+    IMediatorServiceBuilder RegisterRequestHandler<TMessage, THandler>()
+        where THandler : class, IRequestHandler<TMessage, object> =>
+        Register(typeof(TMessage), typeof(THandler));
+
+    /// <summary>
+    /// Registers a stream handler for a specific message type.
+    /// </summary>
+    /// <typeparam name="TMessage">The type of the message to handle.</typeparam>
+    /// <typeparam name="THandler">The type of the validation handler.</typeparam>
     /// <returns>The <see cref="IMediatorServiceBuilder"/> instance for chaining.</returns>
     IMediatorServiceBuilder RegisterStreamHandler<TMessage, THandler>()
         where THandler : class, IStreamHandler<TMessage, object> =>

--- a/src/NetMediate/Internals/MediatorServiceBuilder.cs
+++ b/src/NetMediate/Internals/MediatorServiceBuilder.cs
@@ -67,9 +67,7 @@ internal sealed class MediatorServiceBuilder : IMediatorServiceBuilder
         return this;
     }
 
-    private MediatorServiceBuilder Filter<TMessage, THandler, TBase>(
-        Func<TMessage, bool> filter
-    )
+    private MediatorServiceBuilder Filter<TMessage, THandler, TBase>(Func<TMessage, bool> filter)
     {
         RegisterType(typeof(TBase), typeof(THandler));
 
@@ -156,9 +154,14 @@ internal sealed class MediatorServiceBuilder : IMediatorServiceBuilder
             );
         }
 
-        var interfaces = handlerType.GetInterfaces()
-            .Where(i => i.IsGenericType && s_validInterface.Contains(i.GetGenericTypeDefinition()) &&
-                i.GenericTypeArguments.Length >= 1 && i.GenericTypeArguments[0] == messageType)
+        var interfaces = handlerType
+            .GetInterfaces()
+            .Where(i =>
+                i.IsGenericType
+                && s_validInterface.Contains(i.GetGenericTypeDefinition())
+                && i.GenericTypeArguments.Length >= 1
+                && i.GenericTypeArguments[0] == messageType
+            )
             .ToArray();
 
         if (interfaces.Length == 0)
@@ -177,8 +180,15 @@ internal sealed class MediatorServiceBuilder : IMediatorServiceBuilder
         Type? handlerInterface = null
     )
     {
-        handlerInterface ??= types.Select((type, _) => type.interfaces.FirstOrDefault(ifce => s_validInterface.Contains(ifce.GetGenericTypeDefinition())))
-            .FirstOrDefault().GetGenericTypeDefinition();
+        handlerInterface ??= types
+            .Select(
+                (type, _) =>
+                    type.interfaces.FirstOrDefault(ifce =>
+                        s_validInterface.Contains(ifce.GetGenericTypeDefinition())
+                    )
+            )
+            .FirstOrDefault()
+            .GetGenericTypeDefinition();
 
         var handlerTypes = types
             .Where(type =>
@@ -202,8 +212,9 @@ internal sealed class MediatorServiceBuilder : IMediatorServiceBuilder
 
     private void RegisterType(Type interfaceType, Type handlerType)
     {
-        var unique = interfaceType.GetGenericTypeDefinition() != typeof(INotificationHandler<>) &&
-            interfaceType.GetGenericTypeDefinition() != typeof(IValidationHandler<>);
+        var unique =
+            interfaceType.GetGenericTypeDefinition() != typeof(INotificationHandler<>)
+            && interfaceType.GetGenericTypeDefinition() != typeof(IValidationHandler<>);
 
         if (unique)
             UniqueRegisterType(interfaceType, handlerType);

--- a/src/NetMediate/Internals/MediatorServiceBuilder.cs
+++ b/src/NetMediate/Internals/MediatorServiceBuilder.cs
@@ -186,8 +186,16 @@ internal sealed class MediatorServiceBuilder : IMediatorServiceBuilder
                     s_validInterface.Contains(ifce.GetGenericTypeDefinition())
                 )
             )
-            .First()
+            .FirstOrDefault()?
             .GetGenericTypeDefinition();
+
+        if (handlerInterface is null)
+        {
+            throw new ArgumentException(
+                "No valid handler interface found in the provided types.",
+                nameof(handlerInterface)
+            );
+        }
 
         var handlerTypes = types
             .Where(type =>

--- a/src/NetMediate/Internals/MediatorServiceBuilder.cs
+++ b/src/NetMediate/Internals/MediatorServiceBuilder.cs
@@ -183,11 +183,11 @@ internal sealed class MediatorServiceBuilder : IMediatorServiceBuilder
         handlerInterface ??= types
             .Select(
                 (type, _) =>
-                    type.interfaces.FirstOrDefault(ifce =>
+                    type.interfaces.First(ifce =>
                         s_validInterface.Contains(ifce.GetGenericTypeDefinition())
                     )
             )
-            .FirstOrDefault()
+            .First()?
             .GetGenericTypeDefinition();
 
         var handlerTypes = types

--- a/src/NetMediate/Internals/MediatorServiceBuilder.cs
+++ b/src/NetMediate/Internals/MediatorServiceBuilder.cs
@@ -68,11 +68,10 @@ internal sealed class MediatorServiceBuilder : IMediatorServiceBuilder
     }
 
     private MediatorServiceBuilder Filter<TMessage, THandler, TBase>(
-        Func<TMessage, bool> filter,
-        bool unique = true
+        Func<TMessage, bool> filter
     )
     {
-        Register(typeof(TBase), typeof(THandler), unique);
+        RegisterType(typeof(TBase), typeof(THandler));
 
         _configuration.InstantiateHandlerByMessageFilter<TMessage>(message =>
         {
@@ -88,7 +87,7 @@ internal sealed class MediatorServiceBuilder : IMediatorServiceBuilder
         Func<TMessage, bool> filter
     )
         where THandler : class, INotificationHandler<TMessage> =>
-        Filter<TMessage, THandler, INotificationHandler<TMessage>>(filter, false);
+        Filter<TMessage, THandler, INotificationHandler<TMessage>>(filter);
 
     public IMediatorServiceBuilder FilterCommand<TMessage, THandler>(Func<TMessage, bool> filter)
         where THandler : class, ICommandHandler<TMessage> =>
@@ -121,11 +120,11 @@ internal sealed class MediatorServiceBuilder : IMediatorServiceBuilder
     ];
 
     private void MapValidationHandlers(IEnumerable<(Type handlerType, Type[] interfaces)> types) =>
-        Map(types, typeof(IValidationHandler<>), false);
+        Map(types, typeof(IValidationHandler<>));
 
     private void MapNotificationHandlers(
         IEnumerable<(Type handlerType, Type[] interfaces)> types
-    ) => Map(types, typeof(INotificationHandler<>), false);
+    ) => Map(types, typeof(INotificationHandler<>));
 
     private void MapRequestHandlers(IEnumerable<(Type handlerType, Type[] interfaces)> types) =>
         Map(types, typeof(IRequestHandler<,>));
@@ -136,12 +135,51 @@ internal sealed class MediatorServiceBuilder : IMediatorServiceBuilder
     private void MapStreamHandlers(IEnumerable<(Type handlerType, Type[] interfaces)> types) =>
         Map(types, typeof(IStreamHandler<,>));
 
+    public IMediatorServiceBuilder Register(Type messageType, Type handlerType)
+    {
+        ArgumentNullException.ThrowIfNull(messageType);
+        ArgumentNullException.ThrowIfNull(handlerType);
+
+        var interfaces = GetInterfaces(handlerType, messageType);
+        Map([(handlerType, interfaces)]);
+
+        return this;
+    }
+
+    private static Type[] GetInterfaces(Type handlerType, Type messageType)
+    {
+        if (!handlerType.IsClass || handlerType.IsAbstract)
+        {
+            throw new ArgumentException(
+                $"Handler type '{handlerType.FullName}' must be a non-abstract class.",
+                nameof(handlerType)
+            );
+        }
+
+        var interfaces = handlerType.GetInterfaces()
+            .Where(i => i.IsGenericType && s_validInterface.Contains(i.GetGenericTypeDefinition()) &&
+                i.GenericTypeArguments.Length >= 1 && i.GenericTypeArguments[0] == messageType)
+            .ToArray();
+
+        if (interfaces.Length == 0)
+        {
+            throw new ArgumentException(
+                $"Handler type '{handlerType.FullName}' does not implement any valid handler interfaces.",
+                nameof(handlerType)
+            );
+        }
+
+        return interfaces;
+    }
+
     private void Map(
         IEnumerable<(Type handlerType, Type[] interfaces)> types,
-        Type handlerInterface,
-        bool unique = true
+        Type? handlerInterface = null
     )
     {
+        handlerInterface ??= types.Select((type, _) => type.interfaces.FirstOrDefault(ifce => s_validInterface.Contains(ifce.GetGenericTypeDefinition())))
+            .FirstOrDefault().GetGenericTypeDefinition();
+
         var handlerTypes = types
             .Where(type =>
                 type.interfaces.Any(i =>
@@ -159,18 +197,21 @@ internal sealed class MediatorServiceBuilder : IMediatorServiceBuilder
             .ToList();
 
         foreach (var (handlerType, interfaceType) in handlerTypes)
-            Register(interfaceType, handlerType, unique);
+            RegisterType(interfaceType, handlerType);
     }
 
-    private void Register(Type interfaceType, Type handlerType, bool unique = true)
+    private void RegisterType(Type interfaceType, Type handlerType)
     {
+        var unique = interfaceType.GetGenericTypeDefinition() != typeof(INotificationHandler<>) &&
+            interfaceType.GetGenericTypeDefinition() != typeof(IValidationHandler<>);
+
         if (unique)
-            UniqueRegister(interfaceType, handlerType);
+            UniqueRegisterType(interfaceType, handlerType);
         else
-            MultiRegister(interfaceType, handlerType);
+            MultiRegisterType(interfaceType, handlerType);
     }
 
-    private void UniqueRegister(Type interfaceType, Type handlerType)
+    private void UniqueRegisterType(Type interfaceType, Type handlerType)
     {
         var keyed = handlerType.GetKey();
 
@@ -180,7 +221,7 @@ internal sealed class MediatorServiceBuilder : IMediatorServiceBuilder
             Services.TryAddScoped(interfaceType, handlerType);
     }
 
-    private void MultiRegister(Type interfaceType, Type handlerType)
+    private void MultiRegisterType(Type interfaceType, Type handlerType)
     {
         var keyed = handlerType.GetKey();
         if (keyed is not null)

--- a/src/NetMediate/Internals/MediatorServiceBuilder.cs
+++ b/src/NetMediate/Internals/MediatorServiceBuilder.cs
@@ -182,11 +182,11 @@ internal sealed class MediatorServiceBuilder : IMediatorServiceBuilder
     {
         handlerInterface ??= types
             .Select(type =>
-                type.interfaces.First(ifce =>
+                type.interfaces.FirstOrDefault(ifce =>
                     s_validInterface.Contains(ifce.GetGenericTypeDefinition())
                 )
             )
-            .FirstOrDefault()?
+            .FirstOrDefault(t => t is not null)?
             .GetGenericTypeDefinition();
 
         if (handlerInterface is null)

--- a/src/NetMediate/Internals/MediatorServiceBuilder.cs
+++ b/src/NetMediate/Internals/MediatorServiceBuilder.cs
@@ -181,13 +181,12 @@ internal sealed class MediatorServiceBuilder : IMediatorServiceBuilder
     )
     {
         handlerInterface ??= types
-            .Select(
-                (type, _) =>
-                    type.interfaces.First(ifce =>
-                        s_validInterface.Contains(ifce.GetGenericTypeDefinition())
-                    )
+            .Select(type =>
+                type.interfaces.First(ifce =>
+                    s_validInterface.Contains(ifce.GetGenericTypeDefinition())
+                )
             )
-            .First()?
+            .First()
             .GetGenericTypeDefinition();
 
         var handlerTypes = types

--- a/tests/NetMediate.Tests/Internals/MediatorServiceBuilderTests.cs
+++ b/tests/NetMediate.Tests/Internals/MediatorServiceBuilderTests.cs
@@ -167,25 +167,21 @@ public class MediatorServiceBuilderTests
     public void Map_RegistersHandlers()
     {
         var services = new ServiceCollection();
-        var builder = new MediatorServiceBuilder(services);
-        var types = new[]
-        {
-            (
-                typeof(DummyNotificationHandler),
-                new[] { typeof(INotificationHandler<DummyNotification>) }
-            ),
-            (typeof(DummyCommandHandler), [typeof(ICommandHandler<DummyCommand>)]),
-            (typeof(DummyRequestHandler), [typeof(IRequestHandler<DummyRequest, object>)]),
-            (typeof(DummyStreamHandler), [typeof(IStreamHandler<DummyStream, object>)]),
-            (typeof(DummyValidationHandler), [typeof(IValidationHandler<DummyValidation>)]),
-        };
-        var mapMethod = typeof(MediatorServiceBuilder).GetMethod(
-            "Map",
-            BindingFlags.NonPublic | BindingFlags.Instance
-        );
-        mapMethod!.Invoke(builder, [types, typeof(INotificationHandler<>), false]);
+        var builder = MakeBuilder(services);
+        builder.RegisterNotificationHandler<DummyNotification, DummyNotificationHandler>();
+        builder.RegisterCommandHandler<DummyCommand, DummyCommandHandler>();
+        builder.RegisterRequestHandler<DummyRequest, DummyRequestHandler>();
+        builder.RegisterStreamHandler<DummyStream, DummyStreamHandler>();
+        builder.RegisterValidationHandler<DummyValidation, DummyValidationHandler>();
         Assert.Contains(services, s => s.ImplementationType == typeof(DummyNotificationHandler));
+        Assert.Contains(services, s => s.ImplementationType == typeof(DummyCommandHandler));
+        Assert.Contains(services, s => s.ImplementationType == typeof(DummyRequestHandler));
+        Assert.Contains(services, s => s.ImplementationType == typeof(DummyStreamHandler));
+        Assert.Contains(services, s => s.ImplementationType == typeof(DummyValidationHandler));
     }
+
+    private static IMediatorServiceBuilder MakeBuilder(IServiceCollection services) =>
+        new MediatorServiceBuilder(services);
 
     [Fact]
     public void ExtractTypes_ReturnsExpectedTypes()


### PR DESCRIPTION
Enhance mediator service builder with new handler methods

Updated the `IMediatorServiceBuilder` interface to include new methods for registering notification, command, request, stream, and validation handlers, along with a `Register` method for message-handler pairs.

Refactored the `MediatorServiceBuilder` class to simplify handler registration by removing unnecessary parameters.

Updated tests in `MediatorServiceBuilderTests` to utilize the new registration methods, improving clarity and maintainability.