### PR TITLE
Update GenDI, support record handlers, add related test

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -16,12 +16,12 @@ The table below is updated automatically by CI on every PR benchmark run. System
 | Key | Value |
 |---|---|
 | OS | Linux Ubuntu 24.04.4 LTS (Noble Numbat) |
-| CPU | AMD EPYC 9V74 2.60GHz, 1 CPU, 4 logical and 2 physical cores |
-| .NET SDK | 10.0.203 |
-| Runtime | .NET 10.0.7 (10.0.7, 10.0.726.21808), X64 RyuJIT x86-64-v3 |
-| Last CI run | 2026-05-11 17:37 UTC |
-| Branch | `fix/security` |
-| Commit | `2a8c1cc` |
+| CPU | AMD EPYC 7763 2.45GHz, 1 CPU, 4 logical and 2 physical cores |
+| .NET SDK | 10.0.300 |
+| Runtime | .NET 10.0.8 (10.0.8, 10.0.826.23019), X64 RyuJIT x86-64-v3 |
+| Last CI run | 2026-05-12 22:03 UTC |
+| Branch | `chore/update-packages` |
+| Commit | `e350e10` |
 <!-- ci-environment-end -->
 
 ---
@@ -41,10 +41,10 @@ available, or against stored target-branch values otherwise (±10% = no change o
 <!-- ci-throughput-start -->
 | Benchmark | Mean | Error | Gen0 | Allocated | Alloc Δ | Throughput | vs timing |
 |---|---|---|---|---|---|---|---|
-| Command `Send` | 66.34 ns | ±0.158 ns | 0.0018 | 32 B | ✅ -16 B | ~15.1M msg/s | ✅ improved (-26.7%) |
-| Notification `Notify` | 195.19 ns | ±3.539 ns | 0.0105 | 176 B | ✅ -112 B | ~5.1M msg/s | ⚠️ degraded (+51.5%) |
-| Request `Request` | 50.11 ns | ±0.097 ns | 0.0043 | 72 B | ✅ -40 B | ~20.0M msg/s | ✅ improved (-44.3%) |
-| Stream `RequestStream` | 131.65 ns | ±0.651 ns | 0.0076 | 128 B | ✅ -88 B | ~7.6M msg/s | ✅ improved (-32.9%) |
+| Command `Send` | 74.25 ns | ±0.157 ns | 0.0018 | 32 B | ✅ -16 B | ~13.5M msg/s | ✅ improved (-18.0%) |
+| Notification `Notify` | 193.61 ns | ±2.305 ns | 0.0105 | 176 B | ✅ -112 B | ~5.2M msg/s | ⚠️ degraded (+50.3%) |
+| Request `Request` | 48.63 ns | ±0.144 ns | 0.0043 | 72 B | ✅ -40 B | ~20.6M msg/s | ✅ improved (-45.9%) |
+| Stream `RequestStream` | 135.99 ns | ±1.303 ns | 0.0076 | 128 B | ✅ -88 B | ~7.4M msg/s | ✅ improved (-30.6%) |
 <!-- ci-throughput-end -->
 
 > ¹ Stream measures complete stream invocations (3 items each). Higher throughput = better.
@@ -268,7 +268,7 @@ Thresholds are deliberately lenient to remain green on any CI hardware. Local de
 
 ## Latest CI Benchmark Run
 
-Run: 2026-05-11 17:37 UTC | Branch: `fix/security` | Commit: `2a8c1cc`
+Run: 2026-05-12 22:03 UTC | Branch: `chore/update-packages` | Commit: `e350e10`
 
 > ℹ️ Timing baseline loaded from stored target-branch docs (different run — ±10% is noise).
 
@@ -276,19 +276,19 @@ Run: 2026-05-11 17:37 UTC | Branch: `fix/security` | Commit: `2a8c1cc`
 
 ```
 Linux Ubuntu 24.04.4 LTS (Noble Numbat)
-AMD EPYC 9V74 2.60GHz, 1 CPU, 4 logical and 2 physical cores
-.NET SDK 10.0.203
-Runtime: .NET 10.0.7 (10.0.7, 10.0.726.21808), X64 RyuJIT x86-64-v3
+AMD EPYC 7763 2.45GHz, 1 CPU, 4 logical and 2 physical cores
+.NET SDK 10.0.300
+Runtime: .NET 10.0.8 (10.0.8, 10.0.826.23019), X64 RyuJIT x86-64-v3
 ```
 
 ### Performance summary (BenchmarkDotNet — Throughput job)
 
 | Benchmark | Mean | Error | Gen0 | Allocated | Alloc Δ | Throughput | vs timing |
 |---|---|---|---|---|---|---|---|
-| Command `Send` | 66.34 ns | ±0.158 ns | 0.0018 | 32 B | ✅ -16 B | ~15.1M msg/s | ✅ improved (-26.7%) |
-| Notification `Notify` | 195.19 ns | ±3.539 ns | 0.0105 | 176 B | ✅ -112 B | ~5.1M msg/s | ⚠️ degraded (+51.5%) |
-| Request `Request` | 50.11 ns | ±0.097 ns | 0.0043 | 72 B | ✅ -40 B | ~20.0M msg/s | ✅ improved (-44.3%) |
-| Stream `RequestStream` | 131.65 ns | ±0.651 ns | 0.0076 | 128 B | ✅ -88 B | ~7.6M msg/s | ✅ improved (-32.9%) |
+| Command `Send` | 74.25 ns | ±0.157 ns | 0.0018 | 32 B | ✅ -16 B | ~13.5M msg/s | ✅ improved (-18.0%) |
+| Notification `Notify` | 193.61 ns | ±2.305 ns | 0.0105 | 176 B | ✅ -112 B | ~5.2M msg/s | ⚠️ degraded (+50.3%) |
+| Request `Request` | 48.63 ns | ±0.144 ns | 0.0043 | 72 B | ✅ -40 B | ~20.6M msg/s | ✅ improved (-45.9%) |
+| Stream `RequestStream` | 135.99 ns | ±1.303 ns | 0.0076 | 128 B | ✅ -88 B | ~7.4M msg/s | ✅ improved (-30.6%) |
 
 ### Comparison vs baseline (`main`, median of ≤3 runs)
 
@@ -297,7 +297,7 @@ Runtime: .NET 10.0.7 (10.0.7, 10.0.726.21808), X64 RyuJIT x86-64-v3
 
 | Benchmark | Baseline (`main`, median of ≤3 runs) | Current | Δ timing | Alloc Δ |
 |---|---|---|---|---|
-| Command `Send` | 90.55 ns | 66.34 ns | ✅ -26.7% | ✅ -16 B |
-| Notification `Notify` | 128.85 ns | 195.19 ns | ⚠️ +51.5% | ✅ -112 B |
-| Request `Request` | 89.91 ns | 50.11 ns | ✅ -44.3% | ✅ -40 B |
-| Stream `RequestStream` | 196.07 ns | 131.65 ns | ✅ -32.9% | ✅ -88 B |
+| Command `Send` | 90.55 ns | 74.25 ns | ✅ -18.0% | ✅ -16 B |
+| Notification `Notify` | 128.85 ns | 193.61 ns | ⚠️ +50.3% | ✅ -112 B |
+| Request `Request` | 89.91 ns | 48.63 ns | ✅ -45.9% | ✅ -40 B |
+| Stream `RequestStream` | 196.07 ns | 135.99 ns | ✅ -30.6% | ✅ -88 B |

--- a/src/NetMediate.Core/NetMediate.Core.csproj
+++ b/src/NetMediate.Core/NetMediate.Core.csproj
@@ -28,7 +28,7 @@
 		<None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="GenDI" Version="26.5.11.21" />
+		<PackageReference Include="GenDI" Version="26.5.12.1224" />
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.*" />
 	</ItemGroup>
 

--- a/src/NetMediate.Quartz/NetMediate.Quartz.csproj
+++ b/src/NetMediate.Quartz/NetMediate.Quartz.csproj
@@ -31,15 +31,12 @@
     <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
-	  <PackageReference Include="GenDI.SourceGenerator" Version="26.5.11.21">
+	  <PackageReference Include="GenDI.SourceGenerator" Version="26.5.12.1224">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>
 	  </PackageReference>
     <ProjectReference Include="..\NetMediate\NetMediate.csproj" />
-    <PackageReference
-      Include="Microsoft.Extensions.DependencyInjection.Abstractions"
-      Version="10.*"
-    />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.*" />
     <PackageReference Include="Quartz" Version="3.*" />
     <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.*" />
   </ItemGroup>

--- a/src/NetMediate.SourceGeneration/BehaviorRegistration.cs
+++ b/src/NetMediate.SourceGeneration/BehaviorRegistration.cs
@@ -6,6 +6,6 @@ internal readonly record struct BehaviorRegistration(
     string? ResponseFqn,
     bool HasDiagnostics,
     bool HasResilience,
-    System.Collections.Generic.Dictionary<string, bool> DiagnosticsBehaviors,
-    System.Collections.Generic.Dictionary<string, bool> ResilienceBehaviors
+    Dictionary<string, bool> DiagnosticsBehaviors,
+    Dictionary<string, bool> ResilienceBehaviors
 );

--- a/src/NetMediate.SourceGeneration/NetMediateRegistrationGenerator.cs
+++ b/src/NetMediate.SourceGeneration/NetMediateRegistrationGenerator.cs
@@ -129,18 +129,15 @@ public sealed class NetMediateRegistrationGenerator : IIncrementalGenerator
     }
 
     private static bool Search(SyntaxNode node) =>
-        (node is TypeDeclarationSyntax declaration && declaration.BaseList is not null) ||
-        (node is ClassDeclarationSyntax cds && cds.BaseList is not null);
+        node is TypeDeclarationSyntax declaration && declaration.BaseList is not null;
 
     private static INamedTypeSymbol? Transform(GeneratorSyntaxContext ctx)
     {
-        if (ctx.Node is not TypeDeclarationSyntax typeDec || ctx.SemanticModel.GetDeclaredSymbol(typeDec) is not INamedTypeSymbol typeSymbol1)
+        if (ctx.Node is not TypeDeclarationSyntax declaration)
             return null;
 
-        if (ctx.Node is not ClassDeclarationSyntax classDec || ctx.SemanticModel.GetDeclaredSymbol(classDec) is not INamedTypeSymbol typeSymbol2)
+        if (ctx.SemanticModel.GetDeclaredSymbol(declaration) is not INamedTypeSymbol typeSymbol)
             return null;
-
-        var typeSymbol = typeSymbol1 ?? typeSymbol2;
 
         if (typeSymbol.IsAbstract || typeSymbol.IsGenericType)
             return null;

--- a/src/NetMediate.SourceGeneration/NetMediateRegistrationGenerator.cs
+++ b/src/NetMediate.SourceGeneration/NetMediateRegistrationGenerator.cs
@@ -43,10 +43,6 @@ public sealed class NetMediateRegistrationGenerator : IIncrementalGenerator
         );
     }
 
-    // Removed: _names static field, ExtractNames, FindMostCommonBaseNamespace, Compute,
-    // CalculateName. The namespace is now derived per-compilation from the assembly name
-    // directly, matching GenDI's per-project resolution strategy.
-
     private static void Accumulate(
         SourceProductionContext sourceProductionContext,
         (
@@ -133,15 +129,18 @@ public sealed class NetMediateRegistrationGenerator : IIncrementalGenerator
     }
 
     private static bool Search(SyntaxNode node) =>
-        node is ClassDeclarationSyntax cds && cds.BaseList is not null;
+        (node is TypeDeclarationSyntax declaration && declaration.BaseList is not null) ||
+        (node is ClassDeclarationSyntax cds && cds.BaseList is not null);
 
     private static INamedTypeSymbol? Transform(GeneratorSyntaxContext ctx)
     {
-        if (ctx.Node is not ClassDeclarationSyntax declaration)
+        if (ctx.Node is not TypeDeclarationSyntax typeDec || ctx.SemanticModel.GetDeclaredSymbol(typeDec) is not INamedTypeSymbol typeSymbol1)
             return null;
 
-        if (ctx.SemanticModel.GetDeclaredSymbol(declaration) is not INamedTypeSymbol typeSymbol)
+        if (ctx.Node is not ClassDeclarationSyntax classDec || ctx.SemanticModel.GetDeclaredSymbol(classDec) is not INamedTypeSymbol typeSymbol2)
             return null;
+
+        var typeSymbol = typeSymbol1 ?? typeSymbol2;
 
         if (typeSymbol.IsAbstract || typeSymbol.IsGenericType)
             return null;

--- a/src/NetMediate.SourceGeneration/NetMediateRegistrationGenerator.cs
+++ b/src/NetMediate.SourceGeneration/NetMediateRegistrationGenerator.cs
@@ -133,16 +133,14 @@ public sealed class NetMediateRegistrationGenerator : IIncrementalGenerator
 
     private static INamedTypeSymbol? Transform(GeneratorSyntaxContext ctx)
     {
-        if (ctx.Node is not TypeDeclarationSyntax declaration)
-            return null;
+        var declaration = (TypeDeclarationSyntax)ctx.Node;
 
-        if (ctx.SemanticModel.GetDeclaredSymbol(declaration) is not INamedTypeSymbol typeSymbol)
-            return null;
-
-        if (typeSymbol.IsAbstract || typeSymbol.IsGenericType)
-            return null;
-
-        if (!IsAccessible(typeSymbol))
+        if (
+            ctx.SemanticModel.GetDeclaredSymbol(declaration) is not INamedTypeSymbol typeSymbol
+            || typeSymbol.IsAbstract
+            || typeSymbol.IsGenericType
+            || !IsAccessible(typeSymbol)
+        )
             return null;
 
         return typeSymbol;

--- a/src/NetMediate.SourceGeneration/buildTransitive/NetMediate.SourceGeneration.props
+++ b/src/NetMediate.SourceGeneration/buildTransitive/NetMediate.SourceGeneration.props
@@ -1,7 +1,7 @@
 <Project>
 	<ItemGroup>
 		<PackageReference Include="NetMediate" Version="2026.*" />
-		<PackageReference Include="GenDI.SourceGenerator" Version="26.5.11.21" PrivateAssets="all">
+		<PackageReference Include="GenDI.SourceGenerator" Version="26.5.12.1224" PrivateAssets="all">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 	</ItemGroup>

--- a/src/NetMediate/NetMediate.csproj
+++ b/src/NetMediate/NetMediate.csproj
@@ -31,7 +31,7 @@
     <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
-	  <PackageReference Include="GenDI.SourceGenerator" Version="26.5.11.21">
+	  <PackageReference Include="GenDI.SourceGenerator" Version="26.5.12.1224">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>
 	  </PackageReference>

--- a/tests/NetMediate.Benchmarks/NetMediate.Benchmarks.csproj
+++ b/tests/NetMediate.Benchmarks/NetMediate.Benchmarks.csproj
@@ -11,7 +11,7 @@
     <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="GenDI.SourceGenerator" Version="26.5.11.21">
+	<PackageReference Include="GenDI.SourceGenerator" Version="26.5.12.1224">
 		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		<PrivateAssets>all</PrivateAssets>
 	</PackageReference>
@@ -21,11 +21,6 @@
   </ItemGroup>
   <ItemGroup>
 	<ProjectReference Include="..\..\src\NetMediate\NetMediate.csproj" />
-	  <ProjectReference
-		Include="../../src/NetMediate.SourceGeneration/NetMediate.SourceGeneration.csproj"
-		PrivateAssets="all"
-		OutputItemType="Analyzer"
-		ReferenceOutputAssembly="false"
-    />
+	  <ProjectReference Include="../../src/NetMediate.SourceGeneration/NetMediate.SourceGeneration.csproj" PrivateAssets="all" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/tests/NetMediate.Diagnostics.Tests/NetMediate.Diagnostics.Tests.csproj
+++ b/tests/NetMediate.Diagnostics.Tests/NetMediate.Diagnostics.Tests.csproj
@@ -12,7 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="GenDI.SourceGenerator" Version="26.5.11.21">
+    <PackageReference Include="GenDI.SourceGenerator" Version="26.5.12.1224">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/NetMediate.Resilience.Tests/NetMediate.Resilience.Tests.csproj
+++ b/tests/NetMediate.Resilience.Tests/NetMediate.Resilience.Tests.csproj
@@ -12,7 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="GenDI.SourceGenerator" Version="26.5.11.21">
+    <PackageReference Include="GenDI.SourceGenerator" Version="26.5.12.1224">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/NetMediate.SourceGeneration.Tests/GeneratorIntegrationTests.cs
+++ b/tests/NetMediate.SourceGeneration.Tests/GeneratorIntegrationTests.cs
@@ -1230,6 +1230,36 @@ public sealed class GeneratorIntegrationTests
     }
 
     /// <summary>
+    /// Record handlers with a base list must be discovered the same way as class handlers.
+    /// </summary>
+    [Fact]
+    public void Generator_WhenHandlerIsRecord_EmitsRegistrationsAndTypedExtensions()
+    {
+        const string userSource = """
+            using NetMediate;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            namespace MyApp;
+
+            public sealed record PingCommand;
+
+            public sealed record PingHandler() : ICommandHandler<PingCommand>
+            {
+                public Task Handle(PingCommand command, CancellationToken cancellationToken = default)
+                    => Task.CompletedTask;
+            }
+            """;
+
+        var files = RunGeneratorAllFiles(assemblyName: "MyApp.RecordHandler", userSource: userSource);
+        var diSrc = files["NetMediateGeneratedDI.g.cs"];
+        var typedExtensionsSrc = files["NetMediateTypedExtensions.g.cs"];
+
+        Assert.Contains("AddNetMediate", diSrc);
+        Assert.Contains("SendPingCommandAsync", typedExtensionsSrc);
+    }
+
+    /// <summary>
     /// The typed extensions class must be placed in the same generated namespace as
     /// <c>NetMediateGeneratedDI</c> and must NOT be in the <c>NetMediate</c> core namespace.
     /// </summary>

--- a/tests/NetMediate.SourceGeneration.Tests/GeneratorIntegrationTests.cs
+++ b/tests/NetMediate.SourceGeneration.Tests/GeneratorIntegrationTests.cs
@@ -1260,6 +1260,41 @@ public sealed class GeneratorIntegrationTests
     }
 
     /// <summary>
+    /// Generic handler types are type definitions and must be ignored by discovery.
+    /// </summary>
+    [Fact]
+    public void Generator_WhenHandlerTypeIsGeneric_DoesNotRegisterGenericTypeDefinition()
+    {
+        const string userSource = """
+            using NetMediate;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            namespace MyApp;
+
+            public sealed record PingCommand;
+            public sealed record PongCommand;
+
+            public sealed class GenericHandler<T> : ICommandHandler<T>
+            {
+                public Task Handle(T command, CancellationToken cancellationToken = default)
+                    => Task.CompletedTask;
+            }
+
+            public sealed class PongHandler : ICommandHandler<PongCommand>
+            {
+                public Task Handle(PongCommand command, CancellationToken cancellationToken = default)
+                    => Task.CompletedTask;
+            }
+            """;
+
+        var (generatedSource, _) = RunGenerator("MyApp.GenericHandler", userSource);
+
+        Assert.Contains("AddNetMediate", generatedSource);
+        Assert.DoesNotContain("GenericHandler<", generatedSource);
+    }
+
+    /// <summary>
     /// The typed extensions class must be placed in the same generated namespace as
     /// <c>NetMediateGeneratedDI</c> and must NOT be in the <c>NetMediate</c> core namespace.
     /// </summary>

--- a/tests/NetMediate.SourceGeneration.Tests/GeneratorIntegrationTests.cs
+++ b/tests/NetMediate.SourceGeneration.Tests/GeneratorIntegrationTests.cs
@@ -1288,10 +1288,13 @@ public sealed class GeneratorIntegrationTests
             }
             """;
 
-        var (generatedSource, _) = RunGenerator("MyApp.GenericHandler", userSource);
+        var files = RunGeneratorAllFiles(assemblyName: "MyApp.GenericHandler", userSource: userSource);
+        var diSrc = files["NetMediateGeneratedDI.g.cs"];
+        var typedExtensionsSrc = files["NetMediateTypedExtensions.g.cs"];
 
-        Assert.Contains("AddNetMediate", generatedSource);
-        Assert.DoesNotContain("GenericHandler<", generatedSource);
+        Assert.Contains("AddNetMediate", diSrc);
+        Assert.Contains("SendPongCommandAsync", typedExtensionsSrc);
+        Assert.DoesNotContain("GenericHandler<", diSrc);
     }
 
     /// <summary>

--- a/tests/NetMediate.Tests/NetMediate.Tests.csproj
+++ b/tests/NetMediate.Tests/NetMediate.Tests.csproj
@@ -12,7 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="GenDI.SourceGenerator" Version="26.5.11.21">
+    <PackageReference Include="GenDI.SourceGenerator" Version="26.5.12.1224">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/website/docs/performance/benchmarks.md
+++ b/website/docs/performance/benchmarks.md
@@ -20,12 +20,12 @@ The table below is updated automatically by CI on every PR benchmark run. System
 | Key | Value |
 |---|---|
 | OS | Linux Ubuntu 24.04.4 LTS (Noble Numbat) |
-| CPU | AMD EPYC 9V74 2.60GHz, 1 CPU, 4 logical and 2 physical cores |
-| .NET SDK | 10.0.203 |
-| Runtime | .NET 10.0.7 (10.0.7, 10.0.726.21808), X64 RyuJIT x86-64-v3 |
-| Last CI run | 2026-05-11 17:37 UTC |
-| Branch | `fix/security` |
-| Commit | `2a8c1cc` |
+| CPU | AMD EPYC 7763 2.45GHz, 1 CPU, 4 logical and 2 physical cores |
+| .NET SDK | 10.0.300 |
+| Runtime | .NET 10.0.8 (10.0.8, 10.0.826.23019), X64 RyuJIT x86-64-v3 |
+| Last CI run | 2026-05-12 22:03 UTC |
+| Branch | `chore/update-packages` |
+| Commit | `e350e10` |
 <!-- ci-environment-end -->
 
 ---
@@ -45,10 +45,10 @@ available, or against stored target-branch values otherwise (±10% = no change o
 <!-- ci-throughput-start -->
 | Benchmark | Mean | Error | Gen0 | Allocated | Alloc Δ | Throughput | vs timing |
 |---|---|---|---|---|---|---|---|
-| Command `Send` | 66.34 ns | ±0.158 ns | 0.0018 | 32 B | ✅ -16 B | ~15.1M msg/s | ✅ improved (-26.7%) |
-| Notification `Notify` | 195.19 ns | ±3.539 ns | 0.0105 | 176 B | ✅ -112 B | ~5.1M msg/s | ⚠️ degraded (+51.5%) |
-| Request `Request` | 50.11 ns | ±0.097 ns | 0.0043 | 72 B | ✅ -40 B | ~20.0M msg/s | ✅ improved (-44.3%) |
-| Stream `RequestStream` | 131.65 ns | ±0.651 ns | 0.0076 | 128 B | ✅ -88 B | ~7.6M msg/s | ✅ improved (-32.9%) |
+| Command `Send` | 74.25 ns | ±0.157 ns | 0.0018 | 32 B | ✅ -16 B | ~13.5M msg/s | ✅ improved (-18.0%) |
+| Notification `Notify` | 193.61 ns | ±2.305 ns | 0.0105 | 176 B | ✅ -112 B | ~5.2M msg/s | ⚠️ degraded (+50.3%) |
+| Request `Request` | 48.63 ns | ±0.144 ns | 0.0043 | 72 B | ✅ -40 B | ~20.6M msg/s | ✅ improved (-45.9%) |
+| Stream `RequestStream` | 135.99 ns | ±1.303 ns | 0.0076 | 128 B | ✅ -88 B | ~7.4M msg/s | ✅ improved (-30.6%) |
 <!-- ci-throughput-end -->
 
 > ¹ Stream measures complete stream invocations (3 items each). Higher throughput = better.
@@ -272,7 +272,7 @@ Thresholds are deliberately lenient to remain green on any CI hardware. Local de
 
 ## Latest CI Benchmark Run
 
-Run: 2026-05-11 17:37 UTC | Branch: `fix/security` | Commit: `2a8c1cc`
+Run: 2026-05-12 22:03 UTC | Branch: `chore/update-packages` | Commit: `e350e10`
 
 > ℹ️ Timing baseline loaded from stored target-branch docs (different run — ±10% is noise).
 
@@ -280,19 +280,19 @@ Run: 2026-05-11 17:37 UTC | Branch: `fix/security` | Commit: `2a8c1cc`
 
 ```
 Linux Ubuntu 24.04.4 LTS (Noble Numbat)
-AMD EPYC 9V74 2.60GHz, 1 CPU, 4 logical and 2 physical cores
-.NET SDK 10.0.203
-Runtime: .NET 10.0.7 (10.0.7, 10.0.726.21808), X64 RyuJIT x86-64-v3
+AMD EPYC 7763 2.45GHz, 1 CPU, 4 logical and 2 physical cores
+.NET SDK 10.0.300
+Runtime: .NET 10.0.8 (10.0.8, 10.0.826.23019), X64 RyuJIT x86-64-v3
 ```
 
 ### Performance summary (BenchmarkDotNet — Throughput job)
 
 | Benchmark | Mean | Error | Gen0 | Allocated | Alloc Δ | Throughput | vs timing |
 |---|---|---|---|---|---|---|---|
-| Command `Send` | 66.34 ns | ±0.158 ns | 0.0018 | 32 B | ✅ -16 B | ~15.1M msg/s | ✅ improved (-26.7%) |
-| Notification `Notify` | 195.19 ns | ±3.539 ns | 0.0105 | 176 B | ✅ -112 B | ~5.1M msg/s | ⚠️ degraded (+51.5%) |
-| Request `Request` | 50.11 ns | ±0.097 ns | 0.0043 | 72 B | ✅ -40 B | ~20.0M msg/s | ✅ improved (-44.3%) |
-| Stream `RequestStream` | 131.65 ns | ±0.651 ns | 0.0076 | 128 B | ✅ -88 B | ~7.6M msg/s | ✅ improved (-32.9%) |
+| Command `Send` | 74.25 ns | ±0.157 ns | 0.0018 | 32 B | ✅ -16 B | ~13.5M msg/s | ✅ improved (-18.0%) |
+| Notification `Notify` | 193.61 ns | ±2.305 ns | 0.0105 | 176 B | ✅ -112 B | ~5.2M msg/s | ⚠️ degraded (+50.3%) |
+| Request `Request` | 48.63 ns | ±0.144 ns | 0.0043 | 72 B | ✅ -40 B | ~20.6M msg/s | ✅ improved (-45.9%) |
+| Stream `RequestStream` | 135.99 ns | ±1.303 ns | 0.0076 | 128 B | ✅ -88 B | ~7.4M msg/s | ✅ improved (-30.6%) |
 
 ### Comparison vs baseline (`main`, median of ≤3 runs)
 
@@ -301,7 +301,7 @@ Runtime: .NET 10.0.7 (10.0.7, 10.0.726.21808), X64 RyuJIT x86-64-v3
 
 | Benchmark | Baseline (`main`, median of ≤3 runs) | Current | Δ timing | Alloc Δ |
 |---|---|---|---|---|
-| Command `Send` | 90.55 ns | 66.34 ns | ✅ -26.7% | ✅ -16 B |
-| Notification `Notify` | 128.85 ns | 195.19 ns | ⚠️ +51.5% | ✅ -112 B |
-| Request `Request` | 89.91 ns | 50.11 ns | ✅ -44.3% | ✅ -40 B |
-| Stream `RequestStream` | 196.07 ns | 131.65 ns | ✅ -32.9% | ✅ -88 B |
+| Command `Send` | 90.55 ns | 74.25 ns | ✅ -18.0% | ✅ -16 B |
+| Notification `Notify` | 128.85 ns | 193.61 ns | ⚠️ +50.3% | ✅ -112 B |
+| Request `Request` | 89.91 ns | 48.63 ns | ✅ -45.9% | ✅ -40 B |
+| Stream `RequestStream` | 196.07 ns | 135.99 ns | ✅ -30.6% | ✅ -88 B |


### PR DESCRIPTION
Update GenDI, support record handlers, add related test

Updated GenDI/GenDI.SourceGenerator to 26.5.12.1224 in all projects. Generalized generator logic to support record handlers and other type declarations with base lists. Improved BehaviorRegistration type usage. Added a test to ensure record handlers are correctly discovered and registered. Minor .csproj formatting cleanups.