### PR TITLE
Refactor: extract handler caching to ICachedHandlers

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -16,12 +16,12 @@ The table below is updated automatically by CI on every PR benchmark run. System
 | Key | Value |
 |---|---|
 | OS | Linux Ubuntu 24.04.4 LTS (Noble Numbat) |
-| CPU | AMD EPYC 9V74 2.60GHz, 1 CPU, 4 logical and 2 physical cores |
+| CPU | AMD EPYC 7763 2.45GHz, 1 CPU, 4 logical and 2 physical cores |
 | .NET SDK | 10.0.300 |
 | Runtime | .NET 10.0.8 (10.0.8, 10.0.826.23019), X64 RyuJIT x86-64-v3 |
-| Last CI run | 2026-05-29 14:27 UTC |
-| Branch | `chore/discontinuity` |
-| Commit | `9bf5227` |
+| Last CI run | 2026-06-01 13:25 UTC |
+| Branch | `chore/change-lifetime` |
+| Commit | `e922099` |
 <!-- ci-environment-end -->
 
 ---
@@ -38,10 +38,10 @@ The `vs timing` column compares dispatch time against stored target-branch value
 <!-- ci-throughput-start -->
 | Benchmark | Mean | Error | Gen0 | Gen1 | Gen2 | Allocated | Alloc Δ | Throughput | vs timing |
 |---|---|---|---|---|---|---|---|---|---|
-| Command `Send` | 65.46 ns | ±1.908 ns | 0 | 0 | 0 | - | ✅ -48 B | ~15.3M msg/s | ✅ improved (-27.7%) |
-| Notification `Notify` | 121.02 ns | ±18.777 ns | 0.0153 | 0 | 0 | 256 B | ✅ -32 B | ~8.3M msg/s | ≈ (-6.1%) |
-| Request `Request` | 58.59 ns | ±1.276 ns | 0 | 0 | 0 | - | ✅ -112 B | ~17.1M msg/s | ✅ improved (-34.8%) |
-| Stream `RequestStream` | 141.81 ns | ±4.121 ns | 0.0076 | 0 | 0 | 128 B | ✅ -88 B | ~7.1M msg/s | ✅ improved (-27.7%) |
+| Command `Send` | 64.05 ns | ±1.263 ns | 0 | 0 | 0 | - | ✅ -48 B | ~15.6M msg/s | ✅ improved (-29.3%) |
+| Notification `Notify` | 124.97 ns | ±11.272 ns | 0.0151 | 0 | 0 | 256 B | ✅ -32 B | ~8.0M msg/s | ≈ (-3.0%) |
+| Request `Request` | 72.44 ns | ±2.586 ns | 0 | 0 | 0 | - | ✅ -112 B | ~13.8M msg/s | ✅ improved (-19.4%) |
+| Stream `RequestStream` | 140.56 ns | ±2.372 ns | 0.0076 | 0 | 0 | 128 B | ✅ -88 B | ~7.1M msg/s | ✅ improved (-28.3%) |
 <!-- ci-throughput-end -->
 
 > ¹ Stream measures complete stream invocations (3 items each). Higher throughput = better.
@@ -221,7 +221,7 @@ Thresholds are deliberately lenient to remain green on any CI hardware. The Benc
 
 ## Latest CI Benchmark Run
 
-Run: 2026-05-29 14:27 UTC | Branch: `chore/discontinuity` | Commit: `9bf5227`
+Run: 2026-06-01 13:25 UTC | Branch: `chore/change-lifetime` | Commit: `e922099`
 
 ℹ️ Timing baseline loaded from stored target-branch docs (different run — ±10% is noise).
 
@@ -229,7 +229,7 @@ Run: 2026-05-29 14:27 UTC | Branch: `chore/discontinuity` | Commit: `9bf5227`
 
 ```
 Linux Ubuntu 24.04.4 LTS (Noble Numbat)
-AMD EPYC 9V74 2.60GHz, 1 CPU, 4 logical and 2 physical cores
+AMD EPYC 7763 2.45GHz, 1 CPU, 4 logical and 2 physical cores
 .NET SDK 10.0.300
 Runtime: .NET 10.0.8 (10.0.8, 10.0.826.23019), X64 RyuJIT x86-64-v3
 ```
@@ -238,10 +238,10 @@ Runtime: .NET 10.0.8 (10.0.8, 10.0.826.23019), X64 RyuJIT x86-64-v3
 
 | Benchmark | Mean | Error | Gen0 | Gen1 | Gen2 | Allocated | Alloc Δ | Throughput | vs timing |
 |---|---|---|---|---|---|---|---|---|---|
-| Command `Send` | 65.46 ns | ±1.908 ns | 0 | 0 | 0 | - | ✅ -48 B | ~15.3M msg/s | ✅ improved (-27.7%) |
-| Notification `Notify` | 121.02 ns | ±18.777 ns | 0.0153 | 0 | 0 | 256 B | ✅ -32 B | ~8.3M msg/s | ≈ (-6.1%) |
-| Request `Request` | 58.59 ns | ±1.276 ns | 0 | 0 | 0 | - | ✅ -112 B | ~17.1M msg/s | ✅ improved (-34.8%) |
-| Stream `RequestStream` | 141.81 ns | ±4.121 ns | 0.0076 | 0 | 0 | 128 B | ✅ -88 B | ~7.1M msg/s | ✅ improved (-27.7%) |
+| Command `Send` | 64.05 ns | ±1.263 ns | 0 | 0 | 0 | - | ✅ -48 B | ~15.6M msg/s | ✅ improved (-29.3%) |
+| Notification `Notify` | 124.97 ns | ±11.272 ns | 0.0151 | 0 | 0 | 256 B | ✅ -32 B | ~8.0M msg/s | ≈ (-3.0%) |
+| Request `Request` | 72.44 ns | ±2.586 ns | 0 | 0 | 0 | - | ✅ -112 B | ~13.8M msg/s | ✅ improved (-19.4%) |
+| Stream `RequestStream` | 140.56 ns | ±2.372 ns | 0.0076 | 0 | 0 | 128 B | ✅ -88 B | ~7.1M msg/s | ✅ improved (-28.3%) |
 
 ### Comparison vs baseline (`main`, median of ≤3 runs)
 
@@ -250,7 +250,7 @@ Runtime: .NET 10.0.8 (10.0.8, 10.0.826.23019), X64 RyuJIT x86-64-v3
 
 | Benchmark | Baseline (`main`, median of ≤3 runs) | Current | Δ timing | Alloc Δ |
 |---|---|---|---|---|
-| Command `Send` | 90.55 ns | 65.46 ns | ✅ -27.7% | ✅ -48 B |
-| Notification `Notify` | 128.85 ns | 121.02 ns | ≈ -6.1% | ✅ -32 B |
-| Request `Request` | 89.91 ns | 58.59 ns | ✅ -34.8% | ✅ -112 B |
-| Stream `RequestStream` | 196.07 ns | 141.81 ns | ✅ -27.7% | ✅ -88 B |
+| Command `Send` | 90.55 ns | 64.05 ns | ✅ -29.3% | ✅ -48 B |
+| Notification `Notify` | 128.85 ns | 124.97 ns | ≈ -3.0% | ✅ -32 B |
+| Request `Request` | 89.91 ns | 72.44 ns | ✅ -19.4% | ✅ -112 B |
+| Stream `RequestStream` | 196.07 ns | 140.56 ns | ✅ -28.3% | ✅ -88 B |

--- a/src/NetMediate.Core/ICachedHandlers.cs
+++ b/src/NetMediate.Core/ICachedHandlers.cs
@@ -1,0 +1,61 @@
+﻿using GenDI;
+using Microsoft.Extensions.DependencyInjection;
+using System.Collections.Immutable;
+
+namespace NetMediate;
+
+/// <summary>
+/// Represents a service that provides cached lookup of command, notification, request, and stream handlers by message
+/// type and an optional key.
+/// </summary>
+/// <remarks>Implementations return immutable snapshots suitable for concurrent enumeration. The optional key
+/// filters handlers; a null key selects handlers registered without a key. Implementations may throw when a required
+/// request handler cannot be resolved.</remarks>
+[ServiceInjection(ServiceLifetime.Singleton, ThreadIsolation = ThreadIsolationPolicy.None, RegistrationEmission = RegistrationEmissionStrategy.TryAdd, RegistrationMultiplicity = RegistrationMultiplicity.Single)]
+public interface ICachedHandlers
+{
+    /// <summary>
+    /// Returns the command handlers registered for the specified message type and optional key.
+    /// </summary>
+    /// <typeparam name="TMessage">The message type handled by the returned command handlers.</typeparam>
+    /// <param name="key">An optional key that selects a subset of handlers; null selects handlers registered without a key.</param>
+    /// <returns>An immutable array of ICommandHandler{TMessage} instances that match the message type and key; empty if none are
+    /// found.</returns>
+    public ImmutableArray<ICommandHandler<TMessage>> GetCommandHandlers<TMessage>(object? key)
+        where TMessage : notnull;
+
+    /// <summary>
+    /// Gets the notification handlers for the specified message type and optional key.
+    /// </summary>
+    /// <remarks>The returned array is a snapshot of the current handlers and is safe to enumerate without
+    /// external synchronization.</remarks>
+    /// <typeparam name="TMessage">The message type for which to retrieve handlers.</typeparam>
+    /// <param name="key">An optional key used to filter the handlers; may be null.</param>
+    /// <returns>An immutable array of INotificationHandler{TMessage} instances that match the specified type and key.</returns>
+    public ImmutableArray<INotificationHandler<TMessage>> GetNotifyHandlers<TMessage>(object? key)
+        where TMessage : notnull;
+
+    /// <summary>
+    /// Retrieves the request handler for the specified message and response types.
+    /// </summary>
+    /// <remarks>Handler selection is based on the message type and optional key. Implementations may throw if
+    /// no suitable handler is available.</remarks>
+    /// <typeparam name="TMessage">The non-nullable message type to handle.</typeparam>
+    /// <typeparam name="TResponse">The response type produced by the handler.</typeparam>
+    /// <param name="key">An optional key used to resolve a specific handler; null to select the default handler.</param>
+    /// <returns>The resolved IRequestHandler{TMessage, TResponse} for the specified types.</returns>
+    public IRequestHandler<TMessage, TResponse> GetRequestHandler<TMessage, TResponse>(object? key)
+        where TMessage : notnull;
+
+    /// <summary>
+    /// Gets the stream handlers registered for the specified key.
+    /// </summary>
+    /// <remarks>The returned array is immutable and safe for concurrent enumeration.</remarks>
+    /// <typeparam name="TMessage">The message type handled by the returned handlers.</typeparam>
+    /// <typeparam name="TResponse">The response type produced by the returned handlers.</typeparam>
+    /// <param name="key">An optional key used to select handlers; pass null to retrieve handlers registered without a key.</param>
+    /// <returns>An immutable array of IStreamHandler{TMessage, TResponse} that match the given key; empty if none are
+    /// registered.</returns>
+    public ImmutableArray<IStreamHandler<TMessage, TResponse>> GetStreamHandlers<TMessage, TResponse>(object? key)
+        where TMessage : notnull;
+}

--- a/src/NetMediate.Core/IMediator.cs
+++ b/src/NetMediate.Core/IMediator.cs
@@ -6,7 +6,7 @@ namespace NetMediate;
 /// <summary>
 /// Defines a mediator for sending messages, notifications, and requests between components.
 /// </summary>
-[ServiceInjection(ServiceLifetime.Singleton, ThreadIsolation = ThreadIsolationPolicy.None, RegistrationEmission = RegistrationEmissionStrategy.TryAdd, RegistrationMultiplicity = RegistrationMultiplicity.Single)]
+[ServiceInjection(ServiceLifetime.Transient, ThreadIsolation = ThreadIsolationPolicy.None, RegistrationEmission = RegistrationEmissionStrategy.TryAdd, RegistrationMultiplicity = RegistrationMultiplicity.Single)]
 public interface IMediator
 {
     /// <summary>

--- a/src/NetMediate.Core/INotifiable.cs
+++ b/src/NetMediate.Core/INotifiable.cs
@@ -13,7 +13,7 @@ namespace NetMediate;
 /// token.
 /// If you must implement your own, uses [<c>DecoratorFor&lt;INotifiable&gt;</c>] to intercept and do your own implementation.
 /// </remarks>
-[ServiceInjection(ServiceLifetime.Singleton, ThreadIsolation = ThreadIsolationPolicy.None, RegistrationEmission = RegistrationEmissionStrategy.TryAdd, RegistrationMultiplicity = RegistrationMultiplicity.Single)]
+[ServiceInjection(ServiceLifetime.Transient, ThreadIsolation = ThreadIsolationPolicy.None, RegistrationEmission = RegistrationEmissionStrategy.TryAdd, RegistrationMultiplicity = RegistrationMultiplicity.Single)]
 public interface INotifiable
 {
     /// <summary>

--- a/src/NetMediate/CachedHandlers.cs
+++ b/src/NetMediate/CachedHandlers.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.ComponentModel;
+
+namespace NetMediate;
+
+[Injectable]
+[Browsable(false)]
+[EditorBrowsable(EditorBrowsableState.Never)]
+internal sealed class CachedHandlers : ICachedHandlers
+{
+    [Inject] internal required IServiceProvider ServiceProvider { get; init; }
+
+    private readonly ConcurrentDictionary<(Type, object?), Lazy<object>> _cmdCache = new();
+    private readonly ConcurrentDictionary<(Type, object?), Lazy<object>> _ntfCache = new();
+    private readonly ConcurrentDictionary<(Type, Type, object?), Lazy<object>> _reqCache = new();
+    private readonly ConcurrentDictionary<(Type, Type, object?), Lazy<object>> _streamCache = new();
+
+    public ImmutableArray<ICommandHandler<TMessage>> GetCommandHandlers<TMessage>(object? key)
+        where TMessage : notnull =>
+        (ImmutableArray<ICommandHandler<TMessage>>)(_cmdCache.GetOrAdd(
+            (typeof(TMessage), key),
+            k => new(() => k.Item2 is null ?
+                ServiceProvider.GetServices<ICommandHandler<TMessage>>().ToImmutableArray() :
+                [.. ServiceProvider.GetKeyedServices<ICommandHandler<TMessage>>(k.Item2)]
+            ))).Value;
+
+    public ImmutableArray<INotificationHandler<TMessage>> GetNotifyHandlers<TMessage>(object? key)
+        where TMessage : notnull =>
+        (ImmutableArray<INotificationHandler<TMessage>>)_ntfCache.GetOrAdd(
+            (typeof(TMessage), key),
+            k => new(() => k.Item2 is null ?
+                ServiceProvider.GetServices<INotificationHandler<TMessage>>().ToImmutableArray() :
+                [.. ServiceProvider.GetKeyedServices<INotificationHandler<TMessage>>(k.Item2)]
+            )).Value;
+
+    public IRequestHandler<TMessage, TResponse> GetRequestHandler<TMessage, TResponse>(object? key)
+        where TMessage : notnull =>
+        (IRequestHandler<TMessage, TResponse>)_reqCache.GetOrAdd(
+            (typeof(TMessage), typeof(TResponse), key),
+            k => new(() => k.Item3 is null ?
+                ServiceProvider.GetRequiredService<IRequestHandler<TMessage, TResponse>>() :
+                ServiceProvider.GetRequiredKeyedService<IRequestHandler<TMessage, TResponse>>(k.Item3)
+            )).Value;
+
+    public ImmutableArray<IStreamHandler<TMessage, TResponse>> GetStreamHandlers<TMessage, TResponse>(object? key)
+        where TMessage : notnull =>
+        (ImmutableArray<IStreamHandler<TMessage, TResponse>>)_streamCache.GetOrAdd(
+            (typeof(TMessage), typeof(TResponse), key),
+            k => new(() => k.Item3 is null ?
+                ServiceProvider.GetServices<IStreamHandler<TMessage, TResponse>>().ToImmutableArray() :
+                [.. ServiceProvider.GetKeyedServices<IStreamHandler<TMessage, TResponse>>(k.Item3)]
+            )).Value;
+}

--- a/src/NetMediate/Mediator.cs
+++ b/src/NetMediate/Mediator.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.DependencyInjection;
-using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -8,61 +7,14 @@ using System.Diagnostics.CodeAnalysis;
 namespace NetMediate;
 
 /// <inheritdoc/>
-[Injectable(ServiceLifetime.Singleton, Order = int.MinValue)]
+[Injectable(ServiceLifetime.Transient, Order = int.MinValue)]
 [Browsable(false)]
 [EditorBrowsable(EditorBrowsableState.Never)]
 internal sealed class Mediator : IMediator
 {
-    /// <summary>
-    /// Gets the service provider for resolving dependencies.
-    /// </summary>
-    [Inject] public required IServiceProvider ServiceProvider { get; init; }
+    [Inject] internal required INotifiable Notifier { get; init; }
 
-    /// <summary>
-    /// Gets the notification dispatcher responsible for dispatching notifications to registered handlers.
-    /// </summary>
-    [Inject] public required INotifiable Notifier { get; init; }
-
-    private readonly ConcurrentDictionary<(Type, object?), Lazy<object>> _cmdCache = new();
-    private readonly ConcurrentDictionary<(Type, object?), Lazy<object>> _ntfCache = new();
-    private readonly ConcurrentDictionary<(Type, Type, object?), Lazy<object>> _reqCache = new();
-    private readonly ConcurrentDictionary<(Type, Type, object?), Lazy<object>> _streamCache = new();
-
-    private ImmutableArray<ICommandHandler<TMessage>> GetCommandHandlers<TMessage>(object? key)
-        where TMessage : notnull =>
-        (ImmutableArray<ICommandHandler<TMessage>>)(_cmdCache.GetOrAdd(
-            (typeof(TMessage), key),
-            k => new(() => k.Item2 is null ?
-                ServiceProvider.GetServices<ICommandHandler<TMessage>>().ToImmutableArray() :
-                [.. ServiceProvider.GetKeyedServices<ICommandHandler<TMessage>>(k.Item2)]
-            ))).Value;
-
-    private ImmutableArray<INotificationHandler<TMessage>> GetNotifyHandlers<TMessage>(object? key)
-        where TMessage : notnull =>
-        (ImmutableArray<INotificationHandler<TMessage>>)_ntfCache.GetOrAdd(
-            (typeof(TMessage), key),
-            k => new(() => k.Item2 is null ?
-                ServiceProvider.GetServices<INotificationHandler<TMessage>>().ToImmutableArray() :
-                [.. ServiceProvider.GetKeyedServices<INotificationHandler<TMessage>>(k.Item2)]
-            )).Value;
-
-    private IRequestHandler<TMessage, TResponse> GetRequestHandler<TMessage, TResponse>(object? key)
-        where TMessage : notnull =>
-        (IRequestHandler<TMessage, TResponse>)_reqCache.GetOrAdd(
-            (typeof(TMessage), typeof(TResponse), key),
-            k => new(() => k.Item3 is null ?
-                ServiceProvider.GetRequiredService<IRequestHandler<TMessage, TResponse>>() :
-                ServiceProvider.GetRequiredKeyedService<IRequestHandler<TMessage, TResponse>>(k.Item3)
-            )).Value;
-
-    private ImmutableArray<IStreamHandler<TMessage, TResponse>> GetStreamHandlers<TMessage, TResponse>(object? key)
-        where TMessage : notnull =>
-        (ImmutableArray<IStreamHandler<TMessage, TResponse>>)_streamCache.GetOrAdd(
-            (typeof(TMessage), typeof(TResponse), key),
-            k => new(() => k.Item3 is null ? 
-                ServiceProvider.GetServices<IStreamHandler<TMessage, TResponse>>().ToImmutableArray() :
-                [.. ServiceProvider.GetKeyedServices<IStreamHandler<TMessage, TResponse>>(k.Item3)]
-            )).Value;
+    [Inject] internal required ICachedHandlers Cache { get; init; }
 
     private static async ValueTask DispatchCommandHandlersAsync<TMessage>(
         ImmutableArray<ICommandHandler<TMessage>> handlers,
@@ -123,7 +75,7 @@ internal sealed class Mediator : IMediator
         TMessage message
     ) where TMessage : notnull
     {
-        var handlers = GetNotifyHandlers<TMessage>(key);
+        var handlers = Cache.GetNotifyHandlers<TMessage>(key);
 
         _ = Notifier.DispatchNotifications(key, message, handlers);
     }
@@ -168,7 +120,7 @@ internal sealed class Mediator : IMediator
         try
         {
             await DispatchCommandHandlersAsync(
-                GetCommandHandlers<TMessage>(key),
+                Cache.GetCommandHandlers<TMessage>(key),
                 message,
                 cancellationToken
             ).ConfigureAwait(false);
@@ -244,7 +196,7 @@ internal sealed class Mediator : IMediator
     {
         try
         {
-            var handler = GetRequestHandler<TMessage, TResponse>(key);
+            var handler = Cache.GetRequestHandler<TMessage, TResponse>(key);
 
             return await handler.Handle(message, cancellationToken).ConfigureAwait(false);
         }
@@ -277,7 +229,7 @@ internal sealed class Mediator : IMediator
     )
         where TMessage : notnull
         => BuildStreamDispatch(
-            GetStreamHandlers<TMessage, TResponse>(key),
+            Cache.GetStreamHandlers<TMessage, TResponse>(key),
             message,
             cancellationToken
         );

--- a/src/NetMediate/Notifier.cs
+++ b/src/NetMediate/Notifier.cs
@@ -6,7 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace NetMediate;
 
 /// <inheritdoc/>
-[Injectable(ServiceLifetime.Singleton, Order = int.MinValue)]
+[Injectable(ServiceLifetime.Transient, Order = int.MinValue)]
 [Browsable(false)]
 [EditorBrowsable(EditorBrowsableState.Never)]
 internal sealed class Notifier : INotifiable

--- a/tests/NetMediate.Tests/Internals/MediatorAndNotifierCoverageTests.cs
+++ b/tests/NetMediate.Tests/Internals/MediatorAndNotifierCoverageTests.cs
@@ -31,7 +31,7 @@ public sealed class MediatorAndNotifierCoverageTests
             .AddGenDIServices();
         NetMediate.DependencyInjection.GenDIServiceCollectionExtensions.AddGenDIServices(services);
 
-        var mediator = new Mediator { ServiceProvider = services.BuildServiceProvider(), Notifier = notifier };
+        var mediator = new Mediator { Cache = new CachedHandlers { ServiceProvider = services.BuildServiceProvider() }, Notifier = notifier };
 
         mediator.Notify(new NotificationMessage("one"));
 
@@ -88,7 +88,7 @@ public sealed class MediatorAndNotifierCoverageTests
             services.AddSingleton<ICommandHandler<CommandMessage>>(handler);
         });
 
-        var mediator = new Mediator { ServiceProvider = provider, Notifier = new SpyNotifiable() };
+        var mediator = new Mediator { Cache = new CachedHandlers { ServiceProvider = provider }, Notifier = new SpyNotifiable() };
 
         await mediator.Sends(
             [new CommandMessage(1), new CommandMessage(2)],
@@ -109,7 +109,7 @@ public sealed class MediatorAndNotifierCoverageTests
         var keyedHandler = Assert.IsType<RecordingCommandHandler>(
             provider.GetRequiredKeyedService<ICommandHandler<CommandMessage>>("key-send")
         );
-        var mediator = new Mediator { ServiceProvider = provider, Notifier = new SpyNotifiable() };
+        var mediator = new Mediator { Cache = new CachedHandlers { ServiceProvider = provider }, Notifier = new SpyNotifiable() };
 
         await mediator.Send("key-send", new CommandMessage(33), TestContext.Current.CancellationToken);
 
@@ -125,7 +125,7 @@ public sealed class MediatorAndNotifierCoverageTests
             services.AddSingleton<ICommandHandler<CommandMessage>, ThrowingCommandHandler>();
         });
 
-        var mediator = new Mediator { ServiceProvider = provider, Notifier = new SpyNotifiable() };
+        var mediator = new Mediator { Cache = new CachedHandlers { ServiceProvider = provider }, Notifier = new SpyNotifiable() };
         var exception = await Assert.ThrowsAsync<MediatorException>(() =>
             mediator.Send(new CommandMessage(1), TestContext.Current.CancellationToken).AsTask()
         );
@@ -145,7 +145,7 @@ public sealed class MediatorAndNotifierCoverageTests
         });
 
         using var activity = new Activity("send").Start();
-        var mediator = new Mediator { ServiceProvider = provider, Notifier = new SpyNotifiable() };
+        var mediator = new Mediator { Cache = new CachedHandlers { ServiceProvider = provider }, Notifier = new SpyNotifiable() };
 
         var exception = await Assert.ThrowsAsync<MediatorException>(() =>
             mediator.Send(new CommandMessage(10), TestContext.Current.CancellationToken).AsTask()
@@ -163,7 +163,7 @@ public sealed class MediatorAndNotifierCoverageTests
             services.AddSingleton<ICommandHandler<CommandMessage>, ThrowingMediatorExceptionCommandHandler>();
         });
 
-        var mediator = new Mediator { ServiceProvider = provider, Notifier = new SpyNotifiable() };
+        var mediator = new Mediator { Cache = new CachedHandlers { ServiceProvider = provider }, Notifier = new SpyNotifiable() };
 
         var exception = await Assert.ThrowsAsync<MediatorException>(() =>
             mediator.Send(new CommandMessage(1), TestContext.Current.CancellationToken).AsTask()
@@ -180,7 +180,7 @@ public sealed class MediatorAndNotifierCoverageTests
             services.AddSingleton<IRequestHandler<RequestMessage, Response>, RecordingRequestHandler>();
         });
 
-        var mediator = new Mediator { ServiceProvider = provider, Notifier = new SpyNotifiable() };
+        var mediator = new Mediator { Cache = new CachedHandlers { ServiceProvider = provider }, Notifier = new SpyNotifiable() };
         var response = await mediator.Request<RequestMessage, Response>(
             new RequestMessage(7),
             TestContext.Current.CancellationToken
@@ -199,7 +199,7 @@ public sealed class MediatorAndNotifierCoverageTests
             );
         });
 
-        var mediator = new Mediator { ServiceProvider = provider, Notifier = new SpyNotifiable() };
+        var mediator = new Mediator { Cache = new CachedHandlers { ServiceProvider = provider }, Notifier = new SpyNotifiable() };
         var response = await mediator.Request<RequestMessage, Response>(
             "key-request",
             new RequestMessage(13),
@@ -216,7 +216,7 @@ public sealed class MediatorAndNotifierCoverageTests
         {
         });
 
-        var mediator = new Mediator { ServiceProvider = provider, Notifier = new SpyNotifiable() };
+        var mediator = new Mediator { Cache = new CachedHandlers { ServiceProvider = provider }, Notifier = new SpyNotifiable() };
 
         var exception = await Assert.ThrowsAsync<MediatorException>(() =>
             mediator.Request<RequestMessage, Response>(
@@ -240,7 +240,7 @@ public sealed class MediatorAndNotifierCoverageTests
         });
 
         using var activity = new Activity("request").Start();
-        var mediator = new Mediator { ServiceProvider = provider, Notifier = new SpyNotifiable() };
+        var mediator = new Mediator { Cache = new CachedHandlers { ServiceProvider = provider }, Notifier = new SpyNotifiable() };
 
         var exception = await Assert.ThrowsAsync<MediatorException>(() =>
             mediator.Request<RequestMessage, Response>(
@@ -265,7 +265,7 @@ public sealed class MediatorAndNotifierCoverageTests
             );
         });
 
-        var mediator = new Mediator { ServiceProvider = provider, Notifier = new SpyNotifiable() };
+        var mediator = new Mediator { Cache = new CachedHandlers { ServiceProvider = provider }, Notifier = new SpyNotifiable() };
         var items = await ToList(
             mediator.RequestStream<StreamMessage, int>(
                 new StreamMessage(3),
@@ -286,7 +286,7 @@ public sealed class MediatorAndNotifierCoverageTests
             );
         });
 
-        var mediator = new Mediator { ServiceProvider = provider, Notifier = new SpyNotifiable() };
+        var mediator = new Mediator { Cache = new CachedHandlers { ServiceProvider = provider }, Notifier = new SpyNotifiable() };
         var items = await ToList(
             mediator.RequestStream<StreamMessage, int>(
                 new StreamMessage(3),
@@ -305,7 +305,7 @@ public sealed class MediatorAndNotifierCoverageTests
             services.AddKeyedSingleton<IStreamHandler<StreamMessage, int>, KeyedStreamHandler>("key-stream");
         });
 
-        var mediator = new Mediator { ServiceProvider = provider, Notifier = new SpyNotifiable() };
+        var mediator = new Mediator { Cache = new CachedHandlers { ServiceProvider = provider }, Notifier = new SpyNotifiable() };
         var items = await ToList(
             mediator.RequestStream<StreamMessage, int>(
                 "key-stream",
@@ -322,7 +322,7 @@ public sealed class MediatorAndNotifierCoverageTests
     {
         using var provider = BuildProvider(_ => { });
 
-        var mediator = new Mediator { ServiceProvider = provider, Notifier = new SpyNotifiable() };
+        var mediator = new Mediator { Cache = new CachedHandlers { ServiceProvider = provider }, Notifier = new SpyNotifiable() };
         var items = await ToList(
             mediator.RequestStream<StreamMessage, int>(
                 new StreamMessage(3),
@@ -464,7 +464,7 @@ public sealed class MediatorAndNotifierCoverageTests
         });
 
         var notifier = new Notifier();
-        var mediator = new Mediator { ServiceProvider = provider, Notifier = notifier };
+        var mediator = new Mediator { Cache = new CachedHandlers { ServiceProvider = provider }, Notifier = notifier };
 
         mediator.Notify(null, new NotificationMessage("one"));
         mediator.Notifies(
@@ -484,7 +484,7 @@ public sealed class MediatorAndNotifierCoverageTests
     {
         // Mediator.cs line 63: pipeline is null → early return
         using var provider = new ServiceCollection().BuildServiceProvider();
-        var mediator = new Mediator { ServiceProvider = provider, Notifier = new SpyNotifiable() };
+        var mediator = new Mediator { Cache = new CachedHandlers { ServiceProvider = provider }, Notifier = new SpyNotifiable() };
 
         // The pipeline is simply not registered → should complete without throwing
         var ex = await Record.ExceptionAsync(() =>
@@ -500,7 +500,7 @@ public sealed class MediatorAndNotifierCoverageTests
             services.AddSingleton<ICommandHandler<CommandMessage>, RecordingCommandHandler>();
         });
 
-        var mediator = new Mediator { ServiceProvider = provider, Notifier = new SpyNotifiable() };
+        var mediator = new Mediator { Cache = new CachedHandlers { ServiceProvider = provider }, Notifier = new SpyNotifiable() };
         var exception = await Record.ExceptionAsync(() =>
             mediator.Send(Array.Empty<CommandMessage>(), TestContext.Current.CancellationToken).AsTask()
         );
@@ -513,7 +513,7 @@ public sealed class MediatorAndNotifierCoverageTests
     {
         using var provider = BuildProvider(_ => { });
 
-        var mediator = new Mediator { ServiceProvider = provider, Notifier = new SpyNotifiable() };
+        var mediator = new Mediator { Cache = new CachedHandlers { ServiceProvider = provider }, Notifier = new SpyNotifiable() };
         var exception = await Record.ExceptionAsync(() =>
             mediator.Send(new CommandMessage(12), TestContext.Current.CancellationToken).AsTask()
         );
@@ -530,7 +530,7 @@ public sealed class MediatorAndNotifierCoverageTests
             services.AddSingleton<IRequestHandler<RequestMessage, Response>, ThrowingMediatorExceptionRequestHandler>();
         });
 
-        var mediator = new Mediator { ServiceProvider = provider, Notifier = new SpyNotifiable() };
+        var mediator = new Mediator { Cache = new CachedHandlers { ServiceProvider = provider }, Notifier = new SpyNotifiable() };
 
         var exception = await Assert.ThrowsAsync<MediatorException>(() =>
             mediator.Request<RequestMessage, Response>(
@@ -565,7 +565,7 @@ public sealed class MediatorAndNotifierCoverageTests
         // Notifier.cs line 33: pipeline is null → return Task.CompletedTask
         using var provider = new ServiceCollection().BuildServiceProvider();
         var notifier = new Notifier();
-        var mediator = new Mediator { ServiceProvider = provider, Notifier = notifier };
+        var mediator = new Mediator { Cache = new CachedHandlers { ServiceProvider = provider }, Notifier = notifier };
 
         // The pipeline executor is not registered → should complete without throwing
         var ex = Record.Exception(() =>

--- a/tests/NetMediate.Tests/MoqSupport/NetMediateMoqTests.cs
+++ b/tests/NetMediate.Tests/MoqSupport/NetMediateMoqTests.cs
@@ -135,7 +135,7 @@ public class NetMediateMoqTests
 
         using var provider = services.BuildServiceProvider();
         var notifier = new NotifierMock();
-        var mediator = new Mediator { ServiceProvider = provider, Notifier = notifier };
+        var mediator = new Mediator { Cache = new CachedHandlers { ServiceProvider = provider }, Notifier = notifier };
 
         mediator.Notify(null, new NotifierTestMessage());
 
@@ -162,7 +162,7 @@ public class NetMediateMoqTests
         using var provider = services.BuildServiceProvider();
         var notifier = new NotifierMock();
 
-        var mediator = new Mediator { ServiceProvider = provider, Notifier = notifier };
+        var mediator = new Mediator { Cache = new CachedHandlers { ServiceProvider = provider }, Notifier = notifier };
 
         mediator.Notifies(
             null,

--- a/website/docs/performance/benchmarks.md
+++ b/website/docs/performance/benchmarks.md
@@ -20,12 +20,12 @@ The table below is updated automatically by CI on every PR benchmark run. System
 | Key | Value |
 |---|---|
 | OS | Linux Ubuntu 24.04.4 LTS (Noble Numbat) |
-| CPU | AMD EPYC 9V74 2.60GHz, 1 CPU, 4 logical and 2 physical cores |
+| CPU | AMD EPYC 7763 2.45GHz, 1 CPU, 4 logical and 2 physical cores |
 | .NET SDK | 10.0.300 |
 | Runtime | .NET 10.0.8 (10.0.8, 10.0.826.23019), X64 RyuJIT x86-64-v3 |
-| Last CI run | 2026-05-29 14:27 UTC |
-| Branch | `chore/discontinuity` |
-| Commit | `9bf5227` |
+| Last CI run | 2026-06-01 13:25 UTC |
+| Branch | `chore/change-lifetime` |
+| Commit | `e922099` |
 <!-- ci-environment-end -->
 
 ---
@@ -42,10 +42,10 @@ The `vs timing` column compares dispatch time against stored target-branch value
 <!-- ci-throughput-start -->
 | Benchmark | Mean | Error | Gen0 | Gen1 | Gen2 | Allocated | Alloc Δ | Throughput | vs timing |
 |---|---|---|---|---|---|---|---|---|---|
-| Command `Send` | 65.46 ns | ±1.908 ns | 0 | 0 | 0 | - | ✅ -48 B | ~15.3M msg/s | ✅ improved (-27.7%) |
-| Notification `Notify` | 121.02 ns | ±18.777 ns | 0.0153 | 0 | 0 | 256 B | ✅ -32 B | ~8.3M msg/s | ≈ (-6.1%) |
-| Request `Request` | 58.59 ns | ±1.276 ns | 0 | 0 | 0 | - | ✅ -112 B | ~17.1M msg/s | ✅ improved (-34.8%) |
-| Stream `RequestStream` | 141.81 ns | ±4.121 ns | 0.0076 | 0 | 0 | 128 B | ✅ -88 B | ~7.1M msg/s | ✅ improved (-27.7%) |
+| Command `Send` | 64.05 ns | ±1.263 ns | 0 | 0 | 0 | - | ✅ -48 B | ~15.6M msg/s | ✅ improved (-29.3%) |
+| Notification `Notify` | 124.97 ns | ±11.272 ns | 0.0151 | 0 | 0 | 256 B | ✅ -32 B | ~8.0M msg/s | ≈ (-3.0%) |
+| Request `Request` | 72.44 ns | ±2.586 ns | 0 | 0 | 0 | - | ✅ -112 B | ~13.8M msg/s | ✅ improved (-19.4%) |
+| Stream `RequestStream` | 140.56 ns | ±2.372 ns | 0.0076 | 0 | 0 | 128 B | ✅ -88 B | ~7.1M msg/s | ✅ improved (-28.3%) |
 <!-- ci-throughput-end -->
 
 > ¹ Stream measures complete stream invocations (3 items each). Higher throughput = better.
@@ -225,7 +225,7 @@ Thresholds are deliberately lenient to remain green on any CI hardware. The Benc
 
 ## Latest CI Benchmark Run
 
-Run: 2026-05-29 14:27 UTC | Branch: `chore/discontinuity` | Commit: `9bf5227`
+Run: 2026-06-01 13:25 UTC | Branch: `chore/change-lifetime` | Commit: `e922099`
 
 ℹ️ Timing baseline loaded from stored target-branch docs (different run — ±10% is noise).
 
@@ -233,7 +233,7 @@ Run: 2026-05-29 14:27 UTC | Branch: `chore/discontinuity` | Commit: `9bf5227`
 
 ```
 Linux Ubuntu 24.04.4 LTS (Noble Numbat)
-AMD EPYC 9V74 2.60GHz, 1 CPU, 4 logical and 2 physical cores
+AMD EPYC 7763 2.45GHz, 1 CPU, 4 logical and 2 physical cores
 .NET SDK 10.0.300
 Runtime: .NET 10.0.8 (10.0.8, 10.0.826.23019), X64 RyuJIT x86-64-v3
 ```
@@ -242,10 +242,10 @@ Runtime: .NET 10.0.8 (10.0.8, 10.0.826.23019), X64 RyuJIT x86-64-v3
 
 | Benchmark | Mean | Error | Gen0 | Gen1 | Gen2 | Allocated | Alloc Δ | Throughput | vs timing |
 |---|---|---|---|---|---|---|---|---|---|
-| Command `Send` | 65.46 ns | ±1.908 ns | 0 | 0 | 0 | - | ✅ -48 B | ~15.3M msg/s | ✅ improved (-27.7%) |
-| Notification `Notify` | 121.02 ns | ±18.777 ns | 0.0153 | 0 | 0 | 256 B | ✅ -32 B | ~8.3M msg/s | ≈ (-6.1%) |
-| Request `Request` | 58.59 ns | ±1.276 ns | 0 | 0 | 0 | - | ✅ -112 B | ~17.1M msg/s | ✅ improved (-34.8%) |
-| Stream `RequestStream` | 141.81 ns | ±4.121 ns | 0.0076 | 0 | 0 | 128 B | ✅ -88 B | ~7.1M msg/s | ✅ improved (-27.7%) |
+| Command `Send` | 64.05 ns | ±1.263 ns | 0 | 0 | 0 | - | ✅ -48 B | ~15.6M msg/s | ✅ improved (-29.3%) |
+| Notification `Notify` | 124.97 ns | ±11.272 ns | 0.0151 | 0 | 0 | 256 B | ✅ -32 B | ~8.0M msg/s | ≈ (-3.0%) |
+| Request `Request` | 72.44 ns | ±2.586 ns | 0 | 0 | 0 | - | ✅ -112 B | ~13.8M msg/s | ✅ improved (-19.4%) |
+| Stream `RequestStream` | 140.56 ns | ±2.372 ns | 0.0076 | 0 | 0 | 128 B | ✅ -88 B | ~7.1M msg/s | ✅ improved (-28.3%) |
 
 ### Comparison vs baseline (`main`, median of ≤3 runs)
 
@@ -254,7 +254,7 @@ Runtime: .NET 10.0.8 (10.0.8, 10.0.826.23019), X64 RyuJIT x86-64-v3
 
 | Benchmark | Baseline (`main`, median of ≤3 runs) | Current | Δ timing | Alloc Δ |
 |---|---|---|---|---|
-| Command `Send` | 90.55 ns | 65.46 ns | ✅ -27.7% | ✅ -48 B |
-| Notification `Notify` | 128.85 ns | 121.02 ns | ≈ -6.1% | ✅ -32 B |
-| Request `Request` | 89.91 ns | 58.59 ns | ✅ -34.8% | ✅ -112 B |
-| Stream `RequestStream` | 196.07 ns | 141.81 ns | ✅ -27.7% | ✅ -88 B |
+| Command `Send` | 90.55 ns | 64.05 ns | ✅ -29.3% | ✅ -48 B |
+| Notification `Notify` | 128.85 ns | 124.97 ns | ≈ -3.0% | ✅ -32 B |
+| Request `Request` | 89.91 ns | 72.44 ns | ✅ -19.4% | ✅ -112 B |
+| Stream `RequestStream` | 196.07 ns | 140.56 ns | ✅ -28.3% | ✅ -88 B |


### PR DESCRIPTION
Refactor: extract handler caching to ICachedHandlers

Move handler resolution/caching from Mediator to new ICachedHandlers interface and CachedHandlers implementation. Mediator and Notifier now use transient lifetimes and depend on ICachedHandlers. Update all usages and tests to use the new abstraction. Improves separation of concerns, testability, and maintainability.